### PR TITLE
Feat : #8 로그인 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### env ###
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -24,13 +24,26 @@ repositories {
 }
 
 dependencies {
+	// DB
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	runtimeOnly 'com.h2database:h2'
+
+	// Web
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// JWT
+	compileOnly 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/application/UserService.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/application/UserService.java
@@ -1,0 +1,36 @@
+package com.sparksInTheStep.webBoard.auth.application;
+
+import com.sparksInTheStep.webBoard.auth.application.dto.UserCommand;
+import com.sparksInTheStep.webBoard.auth.domain.User;
+import com.sparksInTheStep.webBoard.auth.persistent.UserRepository;
+import com.sun.jdi.request.DuplicateRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    public void makeNewUser(UserCommand userCommand){
+        if(isExistUser(userCommand.nickname())){
+            throw new DuplicateRequestException("이미 존재하는 닉네임 입니다");
+        }
+
+        userRepository.save(User.of(userCommand.nickname(), userCommand.password()));
+    }
+
+    public boolean passCheck(UserCommand userCommand){
+        if(isExistUser(userCommand.nickname())){
+            User savedUser = userRepository.findByNickname(userCommand.nickname());
+            User checkUser = User.of(userCommand.nickname(), userCommand.password());
+
+            return savedUser.passCheck(checkUser.getPassword());
+        }
+        return false;
+    }
+
+    public boolean isExistUser(String nickname){
+        return userRepository.existsByNickname(nickname);
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/application/dto/UserCommand.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/application/dto/UserCommand.java
@@ -1,0 +1,10 @@
+package com.sparksInTheStep.webBoard.auth.application.dto;
+
+import com.sparksInTheStep.webBoard.auth.domain.User;
+import com.sparksInTheStep.webBoard.auth.presentation.dto.UserRequest;
+
+public record UserCommand(String nickname, String password) {
+    public static UserCommand from(UserRequest userRequest){
+        return new UserCommand(userRequest.nickname(), userRequest.password());
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/application/dto/UserInfo.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/application/dto/UserInfo.java
@@ -1,0 +1,7 @@
+package com.sparksInTheStep.webBoard.auth.application.dto;
+
+public record UserInfo(String nickname) {
+    public static UserInfo of(String nickname){
+        return new UserInfo(nickname);
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/domain/User.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/domain/User.java
@@ -1,0 +1,41 @@
+package com.sparksInTheStep.webBoard.auth.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(unique = true, nullable = false)
+    private String nickname;
+    @Column(nullable = false)
+    private UUID password;
+
+    private User(String nickname, String password){
+        this.nickname = nickname;
+        this.password = encodePassword(password);
+    }
+
+    public static User of(String nickname, String password){
+        return new User(nickname, password);
+    }
+
+    private UUID encodePassword(String password){
+        long seed = password.hashCode();
+        return new UUID(seed, ~seed);
+    }
+
+    public boolean passCheck(UUID password){
+        return this.password.equals(password);
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/persistent/UserRepository.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/persistent/UserRepository.java
@@ -1,0 +1,10 @@
+package com.sparksInTheStep.webBoard.auth.persistent;
+
+import com.sparksInTheStep.webBoard.auth.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    public boolean existsByNickname(String nickname);
+
+    public User findByNickname(String nickname);
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/presentation/UserController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/presentation/UserController.java
@@ -1,0 +1,39 @@
+package com.sparksInTheStep.webBoard.auth.presentation;
+
+import com.sparksInTheStep.webBoard.auth.application.UserService;
+import com.sparksInTheStep.webBoard.auth.application.dto.UserCommand;
+import com.sparksInTheStep.webBoard.auth.presentation.dto.UserRequest;
+import com.sparksInTheStep.webBoard.auth.util.JwtUtil;
+import com.sparksInTheStep.webBoard.auth.util.Token;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody UserRequest userRequest){
+        if(userService.passCheck(UserCommand.from(userRequest))){
+            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        }
+
+        String accessToken = JwtUtil.makeAccessToken(userRequest.nickname());
+        return new ResponseEntity<>(Token.of(accessToken), HttpStatus.OK);
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<?> register(@RequestBody UserRequest userRequest){
+        userService.makeNewUser(UserCommand.from(userRequest));
+
+        String accessToken = JwtUtil.makeAccessToken(userRequest.nickname());
+        return new ResponseEntity<>(Token.of(accessToken), HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/presentation/dto/UserRequest.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/presentation/dto/UserRequest.java
@@ -1,0 +1,4 @@
+package com.sparksInTheStep.webBoard.auth.presentation.dto;
+
+public record UserRequest(String nickname, String password) {
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/presentation/dto/UserResponse.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/presentation/dto/UserResponse.java
@@ -1,0 +1,4 @@
+package com.sparksInTheStep.webBoard.auth.presentation.dto;
+
+public record UserResponse(String nickname) {
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/util/JwtUtil.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/util/JwtUtil.java
@@ -1,0 +1,49 @@
+package com.sparksInTheStep.webBoard.auth.util;
+
+import com.sparksInTheStep.webBoard.auth.presentation.dto.UserRequest;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.Date;
+
+public class JwtUtil {
+    @Value("${KEY}")
+    private static String secretKey;
+
+    @Value("${TOKEN_EXPIRE_LENGTH}")
+    private static long validTime;
+
+    /*
+     * 토큰 생성 : Claim => nickname
+     */
+    public static String makeAccessToken(String nickname) {
+        Long nowMillis = System.currentTimeMillis();
+        Date now = new Date(System.currentTimeMillis());
+
+        String accessToken = Jwts.builder()
+                .claim("nickname", nickname)
+                .issuedAt(now)
+                .expiration(new Date(nowMillis + validTime))
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .compact();
+
+        return accessToken;
+    }
+    /*
+     * 토큰에서 클레임 ( nickname ) 추출
+     */
+    public static String getNicknameFromToken(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+            return claims.get("nickname", String.class);
+        } catch(Exception e){
+            return "null";
+        }
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/util/Token.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/util/Token.java
@@ -1,0 +1,7 @@
+package com.sparksInTheStep.webBoard.auth.util;
+
+public record Token(String accessToken) {
+    public static Token of(String accessToken){
+        return new Token(accessToken);
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/global/annotation/AuthorizedUser.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/annotation/AuthorizedUser.java
@@ -1,0 +1,11 @@
+package com.sparksInTheStep.webBoard.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface AuthorizedUser {
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/global/filter/MemberArgumentResolver.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/filter/MemberArgumentResolver.java
@@ -1,0 +1,46 @@
+package com.sparksInTheStep.webBoard.global.filter;
+
+import com.sparksInTheStep.webBoard.auth.application.UserService;
+import com.sparksInTheStep.webBoard.auth.application.dto.UserInfo;
+import com.sparksInTheStep.webBoard.auth.util.JwtUtil;
+import com.sparksInTheStep.webBoard.global.annotation.AuthorizedUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class MemberArgumentResolver implements HandlerMethodArgumentResolver {
+    private final UserService userService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthorizedUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        String token = webRequest.getHeader("Authorization");
+        if (token == null || !token.startsWith("Bearer ")) {
+            throw new IllegalArgumentException("인증 방식이 잘못되었거나, 토큰이 없습니다!");
+        }
+
+        token = token.substring(7); // "Bearer " 부분을 제거
+
+        String nickname = JwtUtil.getNicknameFromToken(token);
+        if(!userService.isExistUser(nickname)) {
+            throw new IllegalArgumentException("유효하지 않은 로그인 정보입니다!");
+        }
+
+        return UserInfo.of(nickname);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,11 @@
 spring.application.name=webBoard
+# h2-console enable
+spring.h2.console.enabled=true
+# db url
+spring.datasource.url=jdbc:h2:mem:test
+# jpa-set
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.properties.hibernate.format_sql=true
+# auth
+key=${KEY}
+token-expire-length=${TOKEN_EXPIRE_LENGTH}


### PR DESCRIPTION
## PR 제목

### 구현 내용

1. JWT, H2 종속성 추가
2. 환경 변수 추가, 민감 정보는 env 파일로 뺌 ( gitIgnore에 env 추가 )
3. 유저 도메인 구성 ( Persistent - Application - Presentation + Util, Domain )
4. JWT 유틸 클래스 구현
5. 토큰 DTO 구현 
6. 커스텀 어노테이션과 Resolver 구현

### 구현 이유

1. 해당 기능을 사용하기 위해
2. 환경 변수는 토큰의 key와 유효 시간 표시를 위해 사용
3. 로그인 사용자 정보를 저장하기 위해 구성
4. 토큰의 발급, 토큰에서 유저 정보 추출을 위해 구현
5. 클라이언트에 반환할 때, JSON 값을 예쁘게 보내기 위해 구현
6. 로그인 사용자 검증을 위해 구현

### 버그 리포트

- 없음
