### PR TITLE
Feat : #23 어드민 기능과 어드민 페이지 구현

### DIFF
--- a/src/main/java/com/sparksInTheStep/webBoard/admin/presentation/AdminApiController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/admin/presentation/AdminApiController.java
@@ -2,34 +2,36 @@ package com.sparksInTheStep.webBoard.admin.presentation;
 
 import com.sparksInTheStep.webBoard.auth.application.MemberService;
 import com.sparksInTheStep.webBoard.auth.application.dto.MemberInfo;
-import com.sparksInTheStep.webBoard.auth.persistent.MemberRepository;
-import com.sparksInTheStep.webBoard.auth.presentation.dto.MemberRequest;
 import com.sparksInTheStep.webBoard.auth.presentation.dto.MemberResponse;
 import com.sparksInTheStep.webBoard.global.annotation.AuthorizedUser;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/member")
+@RequestMapping("/members")
 public class AdminApiController {
     public final MemberService memberService;
 
     @GetMapping
-    public ResponseEntity<?> readAllUsers(@AuthorizedUser MemberInfo memberInfo) {
+    public ResponseEntity<?> readAllUsers(
+            @AuthorizedUser MemberInfo.Default memberInfo,
+            @PageableDefault Pageable pageable
+    ) {
         return new ResponseEntity<>(
-                memberService.readAllMembers(memberInfo.nickname()).stream()
-                        .map(MemberResponse::from)
-                        .toList(),
+                memberService.readAllMembers(memberInfo.nickname(),pageable)
+                        .map(MemberResponse.Special::from),
                 HttpStatus.OK
         );
     }
 
     @PatchMapping("{userId}")
     public ResponseEntity<?> makeUserAdmin(
-            @AuthorizedUser MemberInfo memberInfo,
+            @AuthorizedUser MemberInfo.Default memberInfo,
             @PathVariable Long userId
     ) {
         memberService.grantingMember(memberInfo.nickname(), userId);
@@ -38,7 +40,7 @@ public class AdminApiController {
 
     @DeleteMapping("{userId}")
     public ResponseEntity<?> deleteUser(
-            @AuthorizedUser MemberInfo memberInfo,
+            @AuthorizedUser MemberInfo.Default memberInfo,
             @PathVariable Long userId
     ) {
         memberService.deleteMember(memberInfo.nickname(), userId);

--- a/src/main/java/com/sparksInTheStep/webBoard/admin/presentation/AdminApiController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/admin/presentation/AdminApiController.java
@@ -1,0 +1,47 @@
+package com.sparksInTheStep.webBoard.admin.presentation;
+
+import com.sparksInTheStep.webBoard.auth.application.MemberService;
+import com.sparksInTheStep.webBoard.auth.application.dto.MemberInfo;
+import com.sparksInTheStep.webBoard.auth.persistent.MemberRepository;
+import com.sparksInTheStep.webBoard.auth.presentation.dto.MemberRequest;
+import com.sparksInTheStep.webBoard.auth.presentation.dto.MemberResponse;
+import com.sparksInTheStep.webBoard.global.annotation.AuthorizedUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member")
+public class AdminApiController {
+    public final MemberService memberService;
+
+    @GetMapping
+    public ResponseEntity<?> readAllUsers(@AuthorizedUser MemberInfo memberInfo) {
+        return new ResponseEntity<>(
+                memberService.readAllMembers(memberInfo.nickname()).stream()
+                        .map(MemberResponse::from)
+                        .toList(),
+                HttpStatus.OK
+        );
+    }
+
+    @PatchMapping("{userId}")
+    public ResponseEntity<?> makeUserAdmin(
+            @AuthorizedUser MemberInfo memberInfo,
+            @PathVariable Long userId
+    ) {
+        memberService.grantingMember(memberInfo.nickname(), userId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @DeleteMapping("{userId}")
+    public ResponseEntity<?> deleteUser(
+            @AuthorizedUser MemberInfo memberInfo,
+            @PathVariable Long userId
+    ) {
+        memberService.deleteMember(memberInfo.nickname(), userId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/admin/presentation/AdminPageController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/admin/presentation/AdminPageController.java
@@ -1,0 +1,14 @@
+package com.sparksInTheStep.webBoard.admin.presentation;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/admin")
+public class AdminPageController {
+    @GetMapping
+    public String adminPage(){
+        return "adminPage.html";
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/admin/presentation/AdminPageController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/admin/presentation/AdminPageController.java
@@ -1,14 +1,22 @@
 package com.sparksInTheStep.webBoard.admin.presentation;
 
+import com.sparksInTheStep.webBoard.auth.application.dto.MemberInfo;
+import com.sparksInTheStep.webBoard.global.annotation.AuthorizedUser;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.view.RedirectView;
 
 @Controller
 @RequestMapping("/admin")
 public class AdminPageController {
-    @GetMapping
-    public String adminPage(){
+    @GetMapping()
+    public String adminMemberPage(){
         return "adminPage.html";
+    }
+
+    @GetMapping("/login")
+    public String adminLoginPage(){
+        return "loginPage.html";
     }
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/application/MemberService.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/application/MemberService.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class MemberService {
@@ -35,13 +37,57 @@ public class MemberService {
         return false;
     }
 
+    // 관리자용
+    @Transactional(readOnly = true)
+    public List<MemberInfo> readAllMembers(String nickname){
+        if(!isAdminMember(nickname)){
+            throw CustomException.of(MemberErrorCode.NO_AUTHENTICATION);
+        }
+
+        return memberRepository.findAll().stream()
+                .map(MemberInfo::from)
+                .toList();
+    }
+
+    // 관리자용
+    @Transactional
+    public void grantingMember(String adminNickname, Long memberId) {
+        if(!isAdminMember(adminNickname)){
+            throw CustomException.of(MemberErrorCode.NO_AUTHENTICATION);
+        }
+
+        Member savedMember = memberRepository.findById(memberId).orElseThrow(
+                () -> CustomException.of(MemberErrorCode.NOT_FOUND)
+        );
+        savedMember.granting();
+    }
+
+    // 관리자용
+    @Transactional
+    public void deleteMember(String adminNickname, Long memberId) {
+        if(!isAdminMember(adminNickname)){
+            throw CustomException.of(MemberErrorCode.NO_AUTHENTICATION);
+        }
+
+        memberRepository.deleteById(memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public MemberInfo loginMember(String nickname){
+        return MemberInfo.from(memberRepository.findByNickname(nickname));
+    }
+
     @Transactional(readOnly = true)
     public boolean isExistMember(String nickname){
         return memberRepository.existsByNickname(nickname);
     }
 
     @Transactional(readOnly = true)
-    public MemberInfo loginMember(String nickname){
-        return MemberInfo.from(memberRepository.findByNickname(nickname));
+    public boolean isAdminMember(String nickname){
+        if(!isExistMember(nickname)){
+            throw CustomException.of(MemberErrorCode.NOT_FOUND);
+        }
+
+        return memberRepository.findByNickname(nickname).adminCheck();
     }
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/application/MemberService.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/application/MemberService.java
@@ -26,11 +26,8 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public boolean memberCheck(MemberCommand memberCommand){
-        if(!isExistMember(memberCommand.nickname())){
+        if(isExistMember(memberCommand.nickname())){
             Member savedMember = memberRepository.findByNickname(memberCommand.nickname());
-            if(savedMember == null){
-                throw CustomException.of(MemberErrorCode.NOT_FOUND);
-            }
             Member checkMember = Member.of(memberCommand.nickname(), memberCommand.password());
 
             return savedMember.passCheck(checkMember.getPassword());

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/application/MemberService.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/application/MemberService.java
@@ -4,7 +4,8 @@ import com.sparksInTheStep.webBoard.auth.application.dto.MemberCommand;
 import com.sparksInTheStep.webBoard.auth.application.dto.MemberInfo;
 import com.sparksInTheStep.webBoard.auth.domain.Member;
 import com.sparksInTheStep.webBoard.auth.persistent.MemberRepository;
-import com.sun.jdi.request.DuplicateRequestException;
+import com.sparksInTheStep.webBoard.global.errorHandling.CustomException;
+import com.sparksInTheStep.webBoard.global.errorHandling.errorCode.MemberErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +18,7 @@ public class MemberService {
     @Transactional
     public void makeNewUser(MemberCommand memberCommand){
         if(isExistMember(memberCommand.nickname())){
-            throw new DuplicateRequestException("이미 존재하는 닉네임 입니다");
+            throw CustomException.of(MemberErrorCode.DUPLICATED_NICKNAME);
         }
 
         memberRepository.save(Member.of(memberCommand.nickname(), memberCommand.password()));
@@ -28,7 +29,7 @@ public class MemberService {
         if(!isExistMember(memberCommand.nickname())){
             Member savedMember = memberRepository.findByNickname(memberCommand.nickname());
             if(savedMember == null){
-                throw new NoSuchFieldError("로그인 정보와 일치하지 않습니다");
+                throw CustomException.of(MemberErrorCode.NOT_FOUND);
             }
             Member checkMember = Member.of(memberCommand.nickname(), memberCommand.password());
 

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/application/dto/MemberInfo.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/application/dto/MemberInfo.java
@@ -2,8 +2,16 @@ package com.sparksInTheStep.webBoard.auth.application.dto;
 
 import com.sparksInTheStep.webBoard.auth.domain.Member;
 
-public record MemberInfo(String nickname) {
-    public static MemberInfo from(Member member){
-        return new MemberInfo(member.getNickname());
+public record MemberInfo() {
+    public record Default(String nickname){
+        public static MemberInfo.Default from(Member member){
+            return new MemberInfo.Default(member.getNickname());
+        }
+    }
+
+    public record Special(String nickname, Long id, boolean isAdmin){
+        public static MemberInfo.Special from(Member member){
+            return new MemberInfo.Special(member.getNickname(), member.getId(), member.isAdmin());
+        }
     }
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/domain/Member.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/domain/Member.java
@@ -19,23 +19,33 @@ public class Member {
     private String nickname;
     @Column(nullable = false)
     private UUID password;
+    @Column(nullable = false)
+    private boolean admin;
 
-    private Member(String nickname, String password){
+    private Member(String nickname, String password) {
         this.nickname = nickname;
         this.password = encodePassword(password);
+        this.admin = false;
     }
 
-    public static Member of(String nickname, String password){
+    public static Member of(String nickname, String password) {
         return new Member(nickname, password);
     }
 
-    private UUID encodePassword(String password){
-        long seed = password.hashCode();
-        return new UUID(seed, ~seed);
+    public void granting() {
+        this.admin = true;
     }
 
-    public boolean passCheck(UUID password){
+    public boolean passCheck(UUID password) {
         return this.password.equals(password);
     }
 
+    public boolean adminCheck() {
+        return this.admin;
+    }
+
+    private UUID encodePassword(String password) {
+        long seed = password.hashCode();
+        return new UUID(seed, ~seed);
+    }
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/persistent/MemberRepository.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/persistent/MemberRepository.java
@@ -1,9 +1,13 @@
 package com.sparksInTheStep.webBoard.auth.persistent;
 
 import com.sparksInTheStep.webBoard.auth.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Page<Member> findAll(Pageable pageable);
+
     boolean existsByNickname(String nickname);
 
     Member findByNickname(String nickname);

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/presentation/MemberController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/presentation/MemberController.java
@@ -22,7 +22,7 @@ public class MemberController {
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody MemberRequest memberRequest){
-        if(memberService.memberCheck(MemberCommand.from(memberRequest))){
+        if(!memberService.memberCheck(MemberCommand.from(memberRequest))){
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }
 

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/presentation/MemberController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/presentation/MemberController.java
@@ -37,4 +37,14 @@ public class MemberController {
         String accessToken = jwtTokenProvider.makeAccessToken(memberRequest.nickname());
         return new ResponseEntity<>(Token.of(accessToken), HttpStatus.CREATED);
     }
+
+    @PostMapping("/adminLogin")
+    public ResponseEntity<?> adminLogin(@RequestBody MemberRequest memberRequest){
+        if(!memberService.adminCheck(MemberCommand.from(memberRequest))){
+            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        }
+
+        String accessToken = jwtTokenProvider.makeAccessToken(memberRequest.nickname());
+        return new ResponseEntity<>(Token.of(accessToken), HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/presentation/dto/MemberResponse.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/presentation/dto/MemberResponse.java
@@ -2,8 +2,16 @@ package com.sparksInTheStep.webBoard.auth.presentation.dto;
 
 import com.sparksInTheStep.webBoard.auth.application.dto.MemberInfo;
 
-public record MemberResponse(String nickname) {
-    public static MemberResponse from(MemberInfo memberInfo){
-        return new MemberResponse(memberInfo.nickname());
+public record MemberResponse() {
+    public record Default(String nickname){
+        public static MemberResponse.Default from(MemberInfo.Default memberInfo){
+            return new MemberResponse.Default(memberInfo.nickname());
+        }
+    }
+
+    public record Special(String nickname, Long id, boolean isAdmin){
+        public static MemberResponse.Special from(MemberInfo.Special memberInfo){
+            return new MemberResponse.Special(memberInfo.nickname(), memberInfo.id(), memberInfo.isAdmin());
+        }
     }
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/comment/application/dto/CommentInfo.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/comment/application/dto/CommentInfo.java
@@ -10,14 +10,14 @@ public record CommentInfo(
         Long id,
         String body,
         LocalDateTime createdAt,
-        MemberInfo memberInfo,
+        MemberInfo.Default memberInfo,
         PostInfo postInfo) {
     public static CommentInfo from(Comment comment){
         return new CommentInfo(
                 comment.getId(),
                 comment.getBody(),
                 comment.getCreatedAt(),
-                MemberInfo.from(comment.getMember()),
+                MemberInfo.Default.from(comment.getMember()),
                 PostInfo.from(comment.getPost())
         );
     }

--- a/src/main/java/com/sparksInTheStep/webBoard/comment/presentation/CommentController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/comment/presentation/CommentController.java
@@ -32,7 +32,7 @@ public class CommentController {
 
     @PostMapping
     public ResponseEntity<?> postComment(
-            @AuthorizedUser MemberInfo memberInfo,
+            @AuthorizedUser MemberInfo.Default memberInfo,
             @RequestBody CommentRequest.Create commentRequest
     ) {
         commentService.makeNewComment(
@@ -45,7 +45,7 @@ public class CommentController {
 
     @DeleteMapping("/{commentId}")
     public ResponseEntity<?> deleteComment(
-            @AuthorizedUser MemberInfo memberInfo,
+            @AuthorizedUser MemberInfo.Default memberInfo,
             @PathVariable Long commentId
     ) throws AuthenticationException {
         commentService.deleteComment(memberInfo.nickname(), commentId);

--- a/src/main/java/com/sparksInTheStep/webBoard/comment/presentation/dto/CommentResponse.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/comment/presentation/dto/CommentResponse.java
@@ -10,7 +10,7 @@ public record CommentResponse(
         Long id,
         String body,
         LocalDateTime createdAt,
-        MemberResponse memberResponse,
+        MemberResponse.Default memberResponse,
         PostResponse postResponse
 ) {
     public static CommentResponse from(CommentInfo commentInfo){
@@ -18,7 +18,7 @@ public record CommentResponse(
                 commentInfo.id(),
                 commentInfo.body(),
                 commentInfo.createdAt(),
-                MemberResponse.from(commentInfo.memberInfo()),
+                MemberResponse.Default.from(commentInfo.memberInfo()),
                 PostResponse.from(commentInfo.postInfo())
         );
     }

--- a/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/CustomException.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/CustomException.java
@@ -1,0 +1,23 @@
+package com.sparksInTheStep.webBoard.global.errorHandling;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+    private final String errorCode;
+    private final String errorMessage;
+
+    private CustomException(ErrorCode errorCode) {
+        super(errorCode.message());
+        this.httpStatus = errorCode.httpStatus();
+        this.errorCode = errorCode.code();
+        this.errorMessage = errorCode.message();
+    }
+
+    public static CustomException of(ErrorCode errorCode) {
+        return new CustomException(errorCode);
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/CustomException.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/CustomException.java
@@ -1,5 +1,6 @@
 package com.sparksInTheStep.webBoard.global.errorHandling;
 
+import com.sparksInTheStep.webBoard.global.errorHandling.errorCode.ErrorCode;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/CustomExceptionHandler.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/CustomExceptionHandler.java
@@ -12,7 +12,7 @@ import java.net.URI;
 @RestControllerAdvice
 public class CustomExceptionHandler {
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ProblemDetail> handleInplaceException(
+    public ResponseEntity<ProblemDetail> handleCustomException(
             HttpServletRequest request,
             CustomException exception
     ) {

--- a/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/CustomExceptionHandler.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/CustomExceptionHandler.java
@@ -1,0 +1,43 @@
+package com.sparksInTheStep.webBoard.global.errorHandling;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.net.URI;
+
+@RestControllerAdvice
+public class CustomExceptionHandler {
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ProblemDetail> handleInplaceException(
+            HttpServletRequest request,
+            CustomException exception
+    ) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                exception.getHttpStatus(),
+                exception.getMessage()
+        );
+        problemDetail.setTitle(exception.getErrorCode());
+        problemDetail.setInstance(URI.create(request.getRequestURI()));
+
+        return new ResponseEntity<>(problemDetail, exception.getHttpStatus());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ProblemDetail> handleException(
+            HttpServletRequest request,
+            Exception exception
+    ) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                exception.getMessage()
+        );
+        problemDetail.setTitle("E999");
+        problemDetail.setInstance(URI.create(request.getRequestURI()));
+
+        return new ResponseEntity<>(problemDetail, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/ErrorCode.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/ErrorCode.java
@@ -1,0 +1,11 @@
+package com.sparksInTheStep.webBoard.global.errorHandling;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus httpStatus();
+
+    String code();
+
+    String message();
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/AuthErrorCode.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/AuthErrorCode.java
@@ -1,0 +1,32 @@
+package com.sparksInTheStep.webBoard.global.errorHandling.errorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum AuthErrorCode implements ErrorCode{
+    NOT_AUTHORIZED(HttpStatus.UNAUTHORIZED, "A000", "Authorization Fail"),
+    TOKEN_IS_EMPTY(HttpStatus.BAD_REQUEST, "A001", "not include token"),
+    TOKEN_IS_INVALID(HttpStatus.BAD_REQUEST, "A002", "is not valid auth method (maybe not bearer)");
+
+    private final HttpStatus httpStatus;
+    private final String errorCode;
+    private final String message;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return null;
+    }
+
+    @Override
+    public String code() {
+        return null;
+    }
+
+    @Override
+    public String message() {
+        return null;
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/AuthErrorCode.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/AuthErrorCode.java
@@ -17,16 +17,16 @@ public enum AuthErrorCode implements ErrorCode{
 
     @Override
     public HttpStatus httpStatus() {
-        return null;
+        return this.httpStatus;
     }
 
     @Override
     public String code() {
-        return null;
+        return this.errorCode;
     }
 
     @Override
     public String message() {
-        return null;
+        return this.message;
     }
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/ErrorCode.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.sparksInTheStep.webBoard.global.errorHandling;
+package com.sparksInTheStep.webBoard.global.errorHandling.errorCode;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/MemberErrorCode.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/MemberErrorCode.java
@@ -16,16 +16,16 @@ public enum MemberErrorCode implements ErrorCode{
 
     @Override
     public HttpStatus httpStatus() {
-        return null;
+        return this.httpStatus;
     }
 
     @Override
     public String code() {
-        return null;
+        return this.errorCode;
     }
 
     @Override
     public String message() {
-        return null;
+        return this.message;
     }
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/MemberErrorCode.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/MemberErrorCode.java
@@ -1,0 +1,31 @@
+package com.sparksInTheStep.webBoard.global.errorHandling.errorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemberErrorCode implements ErrorCode{
+    NOT_FOUND(HttpStatus.NOT_FOUND, "M000", "member finding fail"),
+    DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "M001", "already exist nickname");
+
+    private final HttpStatus httpStatus;
+    private final String errorCode;
+    private final String message;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return null;
+    }
+
+    @Override
+    public String code() {
+        return null;
+    }
+
+    @Override
+    public String message() {
+        return null;
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/MemberErrorCode.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/MemberErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum MemberErrorCode implements ErrorCode{
     NOT_FOUND(HttpStatus.NOT_FOUND, "M000", "member finding fail"),
-    DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "M001", "already exist nickname");
+    DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "M001", "already exist nickname"),
+    NO_AUTHENTICATION(HttpStatus.FORBIDDEN, "M002", "you're not admin member");
 
     private final HttpStatus httpStatus;
     private final String errorCode;

--- a/src/main/java/com/sparksInTheStep/webBoard/post/controller/PostController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/post/controller/PostController.java
@@ -21,7 +21,7 @@ public class PostController {
 
     @PostMapping
     public ResponseEntity<String> savePost(
-            @AuthorizedUser MemberInfo memberInfo,
+            @AuthorizedUser MemberInfo.Default memberInfo,
             @RequestBody PostRequest request
     ) {
         postService.createPost(memberInfo.nickname(), PostCommand.from(request));
@@ -30,7 +30,7 @@ public class PostController {
 
     @GetMapping("/my")
     public ResponseEntity<List<PostResponse>> getPostsByMember(
-            @AuthorizedUser MemberInfo memberInfo
+            @AuthorizedUser MemberInfo.Default memberInfo
     ) {
         return ResponseEntity.ok(
                 postService.getPostsByMember(memberInfo).stream().
@@ -41,7 +41,7 @@ public class PostController {
 
     @DeleteMapping
     public ResponseEntity<String> deletePost(
-            @AuthorizedUser MemberInfo memberInfo,
+            @AuthorizedUser MemberInfo.Default memberInfo,
             @RequestBody Long postId
     ) throws AuthenticationException {
         postService.deletePost(memberInfo, postId);

--- a/src/main/java/com/sparksInTheStep/webBoard/post/service/PostService.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/post/service/PostService.java
@@ -28,7 +28,7 @@ public class PostService {
 
     // DB 읽기 동작의 경우에는 readOnly로 할 것
     @Transactional(readOnly = true)
-    public List<PostInfo> getPostsByMember(MemberInfo memberInfo) {
+    public List<PostInfo> getPostsByMember(MemberInfo.Default memberInfo) {
         Member member = memberRepository.findByNickname(memberInfo.nickname());
 
         List<Post> posts = postRepository.findByMember(member);
@@ -45,7 +45,7 @@ public class PostService {
     }
 
     @Transactional
-    public void deletePost(MemberInfo memberInfo, Long postId) throws AuthenticationException {
+    public void deletePost(MemberInfo.Default memberInfo, Long postId) throws AuthenticationException {
         Member member = memberRepository.findByNickname(memberInfo.nickname());
         Post post = postRepository.findPostById(postId)
                 .orElseThrow(

--- a/src/main/java/com/sparksInTheStep/webBoard/post/service/dto/PostInfo.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/post/service/dto/PostInfo.java
@@ -11,7 +11,7 @@ public record PostInfo(
         String title,
         String body,
         PostType tag,
-        MemberInfo memberInfo,
+        MemberInfo.Default memberInfo,
         LocalDateTime startTime,
         LocalDateTime modifiedTime
         ){
@@ -22,7 +22,7 @@ public record PostInfo(
                post.getTitle(),
                post.getBody(),
                post.getTag(),
-               MemberInfo.from(post.getMember()),
+               MemberInfo.Default.from(post.getMember()),
                post.getCreatedDate(),
                post.getLastModifiedDate()
        );

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,15 +2,25 @@
 spring.application.name=webBoard
 spring.config.import=optional:file:.env[.properties]
 
+# data source
+spring.datasource.url=jdbc:h2:mem:test
+
 # h2-console enable
 spring.h2.console.enabled=true
-
-# db url
-spring.datasource.url=jdbc:h2:mem:test
 
 # jpa-set
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.format_sql=true
+
+# add admin temporary
+spring.sql.init.mode=always
+spring.sql.init.data-locations=classpath:sql/data.sql
+
+# visible sql
+spring.jpa.show-sql=true
+
+# Lazy loading sql file
+spring.jpa.defer-datasource-initialization=true
 
 # auth
 key=${KEY}

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -1,0 +1,2 @@
+INSERT INTO member (nickname, password, admin)
+VALUES ('admin', '00000000-02ca-001f-ffff-fffffd35ffe0', true);

--- a/src/main/resources/static/css/admin.css
+++ b/src/main/resources/static/css/admin.css
@@ -1,0 +1,95 @@
+/* styles.css */
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f9f9f9;
+    color: #333;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+h1 {
+    color: #2e8b57; /* Dark green */
+    margin-top: 20px;
+    text-align: center;
+}
+
+.header {
+    width: 100%;
+    height: 60px;
+    background-color: #3cb371; /* Medium sea green */
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: white;
+    font-size: 18px;
+    font-weight: bold;
+}
+
+table {
+    width: 80%;
+    max-width: 900px;
+    margin: 20px auto;
+    border-collapse: collapse;
+    background-color: white;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+table thead tr {
+    background-color: #3cb371; /* Medium sea green */
+    color: white;
+    text-align: left;
+}
+
+table th,
+table td {
+    padding: 12px 15px;
+    border-bottom: 1px solid #ddd;
+    text-align: center;
+}
+
+table tr:last-child td {
+    border-bottom: none;
+}
+
+button {
+    background-color: #3cb371; /* Medium sea green */
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    margin: 10px;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: background-color 0.3s;
+}
+
+button:hover {
+    background-color: #2e8b57; /* Dark green */
+}
+
+button:disabled {
+    background-color: #ccc;
+    cursor: not-allowed;
+}
+
+div {
+    text-align: center;
+    margin-bottom: 20px;
+}
+
+a {
+    color: #3cb371; /* Medium sea green */
+    text-decoration: none;
+    font-weight: bold;
+    transition: color 0.3s;
+}
+
+a:hover {
+    color: #2e8b57; /* Dark green */
+}

--- a/src/main/resources/static/css/login.css
+++ b/src/main/resources/static/css/login.css
@@ -1,0 +1,85 @@
+/* styles.css */
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f4f4f9; /* 연한 회색 */
+    color: #333;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+}
+
+h1 {
+    text-align: center;
+    color: #3cb371; /* Medium sea green */
+    margin-bottom: 20px;
+}
+
+.container {
+    background-color: white;
+    padding: 30px;
+    border-radius: 10px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    width: 300px;
+}
+
+.form-inline {
+    margin-bottom: 15px;
+    display: flex;
+    flex-direction: column;
+}
+
+label {
+    font-size: 14px;
+    margin-bottom: 5px;
+    color: #555;
+}
+
+input[type="text"],
+input[type="password"] {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    font-size: 14px;
+    box-sizing: border-box;
+    transition: border-color 0.3s ease;
+}
+
+input[type="text"]:focus,
+input[type="password"]:focus {
+    border-color: #3cb371; /* Medium sea green */
+    outline: none;
+}
+
+input[type="button"] {
+    width: 100%;
+    padding: 10px;
+    background-color: #3cb371; /* Medium sea green */
+    color: white;
+    border: none;
+    border-radius: 5px;
+    font-size: 16px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+input[type="button"]:hover {
+    background-color: #2e8b57; /* Dark green */
+}
+
+input[type="button"]:active {
+    background-color: #26734d; /* Darker green */
+}
+
+input[type="button"]:focus {
+    outline: none;
+}
+
+@media screen and (max-width: 400px) {
+    .container {
+        width: 90%; /* 작은 화면에서는 폭을 줄임 */
+    }
+}

--- a/src/main/resources/static/js/admin.js
+++ b/src/main/resources/static/js/admin.js
@@ -1,0 +1,99 @@
+var currentPage = 0;
+var pageSize = 10;
+
+$(document).ready(function() {
+    if(localStorage.getItem('token') === null) {
+        window.location.href = '/admin/login';
+    }
+    getMembers(currentPage);
+
+    $('#prevPage').click(function() {
+        if (currentPage > 0) {
+            getMembers(currentPage - 1);
+        }
+    });
+
+    $('#nextPage').click(function() {
+        getMembers(currentPage + 1);
+    });
+});
+
+function getMembers(page){
+    $.ajax({
+        url: '/members' + '?page=' + page + '&size=' + pageSize,
+        method: 'GET',
+        headers : {
+            Authorization: 'Bearer ' + localStorage.getItem("token"),
+        },
+        success: function(data) {
+            var contents = data.content;
+            var tbody = $('#member-tbody');
+            tbody.empty(); // 초기화
+
+            // 데이터에 따라 테이블 행을 생성
+            contents.forEach(function(member) {
+                // 한 행의 내용
+                var row = `
+                        <tr>
+                            <td>${member.id}</td>
+                            <td>${member.nickname}</td>
+                            <td>${member.isAdmin}</td>
+                            <td>
+                                <a href="#" onclick="adminMemberFunction(${member.id})">권한 주기</a>
+                            </td>
+                            <td>
+                                <a href="#" onclick="deleteMemberFunction(${member.id})">삭제</a>
+                            </td>
+                        </tr>
+                    `;
+                tbody.append(row);
+
+                currentPage = data.number;
+
+                $('#prevPage').prop('disabled', data.first);
+                $('#nextPage').prop('disabled', data.last);
+            });
+        },
+        error: function(err) {
+            alert("권한이 없습니다!");
+            window.location.href = '/admin/login';
+        }
+    });
+}
+
+function deleteMemberFunction(id){
+    $.ajax({
+        type: "DELETE",
+        url: "/members/" + id,
+        headers : {
+            Authorization: 'Bearer ' + localStorage.getItem("token"),
+        },
+        success : function(res){
+            $('#member-table').find('tr[data-id="' + id + '"]').remove();
+            alert("유저 ID : " + id + "가 삭제되었습니다.");
+            getMembers(currentPage);
+        },
+        error : function(error){
+            alert("권한이 없습니다");
+            window.location.href = '/admin/login';
+        }
+    })
+}
+
+function adminMemberFunction(id){
+    $.ajax({
+        type: "PATCH",
+        url: "/members/" + id,
+        headers : {
+            Authorization: 'Bearer ' + localStorage.getItem("token"),
+        },
+        success : function(res){
+            alert("유저 ID : " + id + "가 어드민 권한을 얻었습니다.");
+            getMembers(currentPage);
+        },
+        error : function(error){
+            alert("권한이 없습니다");
+            window.location.href = '/admin/login';
+        }
+    })
+}

--- a/src/main/resources/static/js/login.js
+++ b/src/main/resources/static/js/login.js
@@ -1,27 +1,33 @@
 $(document).ready(function() {
-    localStorage.clear();
-});
-
-$("#login").click(function(){
-    var user = {
-        nickname : $("#userId").val(),
-        password : $("#password").val()
-    }
-
-    $.ajax({
-        type : "POST",
-        url : "/auth/adminLogin",
-        contentType: "application/json",
-        datatype : "json",
-        data : JSON.stringify(user),
-        success : function(res) {
-            var value = res['accessToken'];
-            successLogin(value);
-        },
-        error : function(err){
-            alert("로그인 실패! 아이디나 비밀번호를 확인하세요");
+    // 입력 필드에서 Enter 키를 눌렀을 때 로그인 버튼 클릭
+    $("#userId, #password").keydown(function(event) {
+        if (event.key === "Enter") { // Enter 키가 눌렸을 때
+            $("#login").click(); // 로그인 버튼 클릭
         }
-    })
+    });
+
+    // 로그인 버튼 클릭 시 동작
+    $("#login").click(function(){
+        var user = {
+            nickname : $("#userId").val(),
+            password : $("#password").val()
+        };
+
+        $.ajax({
+            type : "POST",
+            url : "/auth/adminLogin",
+            contentType: "application/json",
+            datatype : "json",
+            data : JSON.stringify(user),
+            success : function(res) {
+                var value = res['accessToken'];
+                successLogin(value);
+            },
+            error : function(err){
+                alert("로그인 실패! 아이디나 비밀번호를 확인하세요");
+            }
+        });
+    });
 });
 
 function successLogin(value) {

--- a/src/main/resources/static/js/login.js
+++ b/src/main/resources/static/js/login.js
@@ -1,0 +1,31 @@
+$(document).ready(function() {
+    localStorage.clear();
+});
+
+$("#login").click(function(){
+    var user = {
+        nickname : $("#userId").val(),
+        password : $("#password").val()
+    }
+
+    $.ajax({
+        type : "POST",
+        url : "/auth/adminLogin",
+        contentType: "application/json",
+        datatype : "json",
+        data : JSON.stringify(user),
+        success : function(res) {
+            var value = res['accessToken'];
+            successLogin(value);
+        },
+        error : function(err){
+            alert("로그인 실패! 아이디나 비밀번호를 확인하세요");
+        }
+    })
+});
+
+function successLogin(value) {
+    localStorage.clear();
+    localStorage.setItem('token', value);
+    window.location.href = "/admin";
+}

--- a/src/main/resources/templates/adminPage.html
+++ b/src/main/resources/templates/adminPage.html
@@ -29,7 +29,7 @@
 </table>
 <div>
     <button id="prevPage">Prev</button>
-    <button id="search" onclick="getMembers(currentPage)">검색</button>
+    <button id="search" onclick="getMembers(currentPage)">조회</button>
     <button id="nextPage">Next</button>
 </div>
 </body>

--- a/src/main/resources/templates/adminPage.html
+++ b/src/main/resources/templates/adminPage.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="KR" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>유저 관리 페이지</title>
+    <link rel="stylesheet" href="/css/admin.css">
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="js/admin.js"></script>
+</head>
+<body>
+<div class="header" id="header">
+
+</div>
+<h1>Member Manage Page</h1>
+
+<table id="member-table">
+    <thead>
+    <tr>
+        <th scope="col">Id</th>
+        <th scope="col">Nickname</th>
+        <th scope="col">IsAdmin</th>
+        <th scope="col">Granting</th>
+        <th scope="col">Delete</th>
+    </tr>
+    </thead>
+    <tbody id="member-tbody">
+    <!-- AJAX를 통해 데이터를 로드 -->
+    </tbody>
+</table>
+<div>
+    <button id="prevPage">Prev</button>
+    <button id="search" onclick="getMembers(currentPage)">검색</button>
+    <button id="nextPage">Next</button>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/loginPage.html
+++ b/src/main/resources/templates/loginPage.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>관리자 로그인</title>
     <link rel="stylesheet" href="/css/login.css">
-    <script type="text/javascript" src="http://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="/js/login.js"></script>
 </head>
 <body>

--- a/src/main/resources/templates/loginPage.html
+++ b/src/main/resources/templates/loginPage.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>관리자 로그인</title>
+    <link rel="stylesheet" href="/css/login.css">
+    <script type="text/javascript" src="http://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="/js/login.js"></script>
+</head>
+<body>
+<div class="container">
+    <h1>로그인</h1>
+
+    <div class="form-inline">
+        <label for="userId">닉네임:</label>
+        <input type="text" id="userId" name="userId" required>
+    </div>
+    <div class="form-inline">
+        <label for="password">비밀번호:</label>
+        <input type="password" id="password" name="password" required>
+    </div>
+    <div>
+        <input type="button" id="login" value="로그인">
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## PR 제목

### 구현 내용

- Member 도메인에 Admin 필드 추가
- Admin 동작을 위해 Info, Response DTO의 종류를 Default와 Special로 나눔
- Admin 동작에 대한 에러코드 추가
- Admin 동작 비즈니스 로직 추가
- Admin 동작 API 구현
- Admin 페이지 연결 Controller 구현
- 원활한 테스트를 위하여 Admin 계정을 하나 생성하는 로직 구성 ( data.sql로 초기화 )
- Admin 페이지 구현

### 구현 이유

- 유저의 원활한 관리를 위해 어드민 페이지를 만들었습니다

### 버그 리포트
