### PR TITLE
Feat : #26 swagger로 API 명세를 작성해요

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 	compileOnly 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparksInTheStep/webBoard/admin/presentation/AdminApiController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/admin/presentation/AdminApiController.java
@@ -1,8 +1,8 @@
 package com.sparksInTheStep.webBoard.admin.presentation;
 
-import com.sparksInTheStep.webBoard.auth.application.MemberService;
-import com.sparksInTheStep.webBoard.auth.application.dto.MemberInfo;
-import com.sparksInTheStep.webBoard.auth.presentation.dto.MemberResponse;
+import com.sparksInTheStep.webBoard.member.application.MemberService;
+import com.sparksInTheStep.webBoard.member.application.dto.MemberInfo;
+import com.sparksInTheStep.webBoard.member.presentation.dto.MemberResponse;
 import com.sparksInTheStep.webBoard.global.annotation.AuthorizedUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/members")
-public class AdminApiController {
+public class AdminApiController implements AdminApiSpec{
     public final MemberService memberService;
 
     @GetMapping

--- a/src/main/java/com/sparksInTheStep/webBoard/admin/presentation/AdminApiSpec.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/admin/presentation/AdminApiSpec.java
@@ -1,0 +1,44 @@
+package com.sparksInTheStep.webBoard.admin.presentation;
+
+import com.sparksInTheStep.webBoard.member.application.dto.MemberInfo;
+import com.sparksInTheStep.webBoard.global.annotation.AuthorizedUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "어드민 API", description = "어드민 기능을 담은 API")
+public interface AdminApiSpec {
+    @Operation(summary = "모든 멤버 조회", description = "저장된 모든 멤버를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "성공")
+    @ApiResponse(responseCode = "403", description = "권한 없음")
+    ResponseEntity<?> readAllUsers(
+            @AuthorizedUser MemberInfo.Default memberInfo,
+            @Parameter(description = "따로 값을 주지 않으면 기본값 : size = 10, page = 0")
+            @PageableDefault Pageable pageable
+    );
+
+    @Operation(summary = "어드민 권한 부여", description = "특정 멤버에게 어드민 권한을 부여합니다.")
+    @ApiResponse(responseCode = "200", description = "성공")
+    @ApiResponse(responseCode = "403", description = "권한 없음")
+    @ApiResponse(responseCode = "404", description = "userId에 해당하는 유저 없음")
+    ResponseEntity<?> makeUserAdmin(
+            @AuthorizedUser MemberInfo.Default memberInfo,
+            @Parameter(description = "유저의 ID")
+            @PathVariable Long userId
+    );
+
+    @Operation(summary = "멤버 삭제", description = "특정 멤버를 삭제합니다.")
+    @ApiResponse(responseCode = "204", description = "성공")
+    @ApiResponse(responseCode = "403", description = "권한 없음")
+    @ApiResponse(responseCode = "404", description = "userId에 해당하는 유저 없음")
+    public ResponseEntity<?> deleteUser(
+            @AuthorizedUser MemberInfo.Default memberInfo,
+            @Parameter(description = "유저의 ID")
+            @PathVariable Long userId
+    );
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/admin/presentation/AdminPageController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/admin/presentation/AdminPageController.java
@@ -1,11 +1,8 @@
 package com.sparksInTheStep.webBoard.admin.presentation;
 
-import com.sparksInTheStep.webBoard.auth.application.dto.MemberInfo;
-import com.sparksInTheStep.webBoard.global.annotation.AuthorizedUser;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.servlet.view.RedirectView;
 
 @Controller
 @RequestMapping("/admin")

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/presentation/AuthApiSpec.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/presentation/AuthApiSpec.java
@@ -1,0 +1,38 @@
+package com.sparksInTheStep.webBoard.auth.presentation;
+
+import com.sparksInTheStep.webBoard.member.presentation.dto.MemberRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "인증 API", description = "로그인 및 회원가입 기능을 담은 API")
+public interface AuthApiSpec {
+    @Operation(summary = "일반 로그인", description = "아이디와 비밀번호를 사용하여 로그인합니다.")
+    @ApiResponse(responseCode = "200", description = "성공")
+    @ApiResponse(responseCode = "401", description = "비밀번호 틀림")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 아이디 사용")
+    public ResponseEntity<?> login(
+            @Parameter(description = "멤버의 아이디와 비밀번호")
+            @RequestBody MemberRequest memberRequest
+    );
+
+    @Operation(summary = "회원 가입", description = "아이디와 비밀번호를 사용하여 회원가입합니다.")
+    @ApiResponse(responseCode = "201", description = "성공")
+    @ApiResponse(responseCode = "400", description = "중복 닉네임 사용")
+    public ResponseEntity<?> register(
+            @Parameter(description = "멤버의 아이디와 비밀번호")
+            @RequestBody MemberRequest memberRequest
+    );
+
+    @Operation(summary = "어드민 로그인", description = "아이디와 비밀번호를 사용하여 로그인합니다.")
+    @ApiResponse(responseCode = "200", description = "성공")
+    @ApiResponse(responseCode = "401", description = "어드민 권한이 없는 아이디 사용 or 비밀번호 틀림")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 아이디 사용")
+    public ResponseEntity<?> adminLogin(
+            @Parameter(description = "멤버의 아이디와 비밀번호")
+            @RequestBody MemberRequest memberRequest
+    );
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/presentation/AuthController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/presentation/AuthController.java
@@ -1,8 +1,8 @@
 package com.sparksInTheStep.webBoard.auth.presentation;
 
-import com.sparksInTheStep.webBoard.auth.application.MemberService;
-import com.sparksInTheStep.webBoard.auth.application.dto.MemberCommand;
-import com.sparksInTheStep.webBoard.auth.presentation.dto.MemberRequest;
+import com.sparksInTheStep.webBoard.member.application.MemberService;
+import com.sparksInTheStep.webBoard.member.application.dto.MemberCommand;
+import com.sparksInTheStep.webBoard.member.presentation.dto.MemberRequest;
 import com.sparksInTheStep.webBoard.auth.token.JwtTokenProvider;
 import com.sparksInTheStep.webBoard.auth.token.Token;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
-public class MemberController {
+public class AuthController implements AuthApiSpec{
     private final MemberService memberService;
     private final JwtTokenProvider jwtTokenProvider;
 

--- a/src/main/java/com/sparksInTheStep/webBoard/comment/application/dto/CommentInfo.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/comment/application/dto/CommentInfo.java
@@ -1,6 +1,6 @@
 package com.sparksInTheStep.webBoard.comment.application.dto;
 
-import com.sparksInTheStep.webBoard.auth.application.dto.MemberInfo;
+import com.sparksInTheStep.webBoard.member.application.dto.MemberInfo;
 import com.sparksInTheStep.webBoard.comment.domain.Comment;
 import com.sparksInTheStep.webBoard.post.service.dto.PostInfo;
 

--- a/src/main/java/com/sparksInTheStep/webBoard/comment/domain/Comment.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/comment/domain/Comment.java
@@ -1,6 +1,6 @@
 package com.sparksInTheStep.webBoard.comment.domain;
 
-import com.sparksInTheStep.webBoard.auth.domain.Member;
+import com.sparksInTheStep.webBoard.member.domain.Member;
 import com.sparksInTheStep.webBoard.post.domain.Post;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/sparksInTheStep/webBoard/comment/persistent/CommentRepository.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/comment/persistent/CommentRepository.java
@@ -5,8 +5,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     Page<Comment> findAllByPostId(Long postId, Pageable pageable);
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/comment/presentation/CommentApiSpec.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/comment/presentation/CommentApiSpec.java
@@ -1,0 +1,48 @@
+package com.sparksInTheStep.webBoard.comment.presentation;
+
+import com.sparksInTheStep.webBoard.comment.presentation.dto.CommentRequest;
+import com.sparksInTheStep.webBoard.global.annotation.AuthorizedUser;
+import com.sparksInTheStep.webBoard.member.application.dto.MemberInfo;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "댓글 API", description = "댓글 기능에 대한 API")
+public interface CommentApiSpec {
+    @Operation(summary = "댓글 조회하기", description = "특정 게시글의 댓글을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "성공")
+    @ApiResponse(responseCode = "404", description = "해당 게시글이 존재하지 않음")
+    public ResponseEntity<?> getComment(
+            @Parameter(description = "댓글을 찾기 위한 정보")
+            @RequestBody CommentRequest.Find postParam,
+            @Parameter(description = "따로 값을 주지 않으면 기본값 : size = 10, page = 0")
+            @PageableDefault Pageable pageable
+    );
+
+    @Operation(summary = "댓글 작성하기", description = "특정 게시글에 댓글을 작성합니다.")
+    @ApiResponse(responseCode = "201", description = "성공")
+    @ApiResponse(responseCode = "400", description = "유효하지 않은 토큰")
+    @ApiResponse(responseCode = "404", description = "해당 게시글이 존재하지 않음 or 위조된 토큰 사용")
+    public ResponseEntity<?> postComment(
+            @AuthorizedUser MemberInfo.Default memberInfo,
+            @Parameter(description = "댓글 생성을 위한 정보")
+            @RequestBody CommentRequest.Create commentRequest
+    );
+
+    @Operation(summary = "댓글 삭제하기", description = "특정 게시글의 댓글을 삭제합니다.")
+    @ApiResponse(responseCode = "204", description = "성공")
+    @ApiResponse(responseCode = "400", description = "유효하지 않은 토큰")
+    @ApiResponse(responseCode = "403", description = "로그인 정보와 일치하지 않는 댓글을 삭제 시도")
+    @ApiResponse(responseCode = "404", description = "해당 댓글이 존재하지 않음 or 위조된 토큰 사용")
+    public ResponseEntity<?> deleteComment(
+            @AuthorizedUser MemberInfo.Default memberInfo,
+            @Parameter(description = "삭제할 댓글의 ID")
+            @PathVariable Long commentId
+    );
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/comment/presentation/CommentController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/comment/presentation/CommentController.java
@@ -1,6 +1,6 @@
 package com.sparksInTheStep.webBoard.comment.presentation;
 
-import com.sparksInTheStep.webBoard.auth.application.dto.MemberInfo;
+import com.sparksInTheStep.webBoard.member.application.dto.MemberInfo;
 import com.sparksInTheStep.webBoard.comment.application.CommentService;
 import com.sparksInTheStep.webBoard.comment.application.dto.CommentCommand;
 import com.sparksInTheStep.webBoard.comment.presentation.dto.CommentRequest;
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/comment")
-public class CommentController {
+public class CommentController implements CommentApiSpec{
     private final CommentService commentService;
 
     @GetMapping
@@ -49,7 +49,7 @@ public class CommentController {
     public ResponseEntity<?> deleteComment(
             @AuthorizedUser MemberInfo.Default memberInfo,
             @PathVariable Long commentId
-    ) throws AuthenticationException {
+    ) {
         commentService.deleteComment(memberInfo.nickname(), commentId);
 
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);

--- a/src/main/java/com/sparksInTheStep/webBoard/comment/presentation/dto/CommentResponse.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/comment/presentation/dto/CommentResponse.java
@@ -1,6 +1,6 @@
 package com.sparksInTheStep.webBoard.comment.presentation.dto;
 
-import com.sparksInTheStep.webBoard.auth.presentation.dto.MemberResponse;
+import com.sparksInTheStep.webBoard.member.presentation.dto.MemberResponse;
 import com.sparksInTheStep.webBoard.comment.application.dto.CommentInfo;
 import com.sparksInTheStep.webBoard.post.controller.dto.PostResponse;
 

--- a/src/main/java/com/sparksInTheStep/webBoard/global/annotation/AuthorizedUser.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/annotation/AuthorizedUser.java
@@ -1,5 +1,7 @@
 package com.sparksInTheStep.webBoard.global.annotation;
 
+import io.swagger.v3.oas.annotations.Parameter;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,5 +9,6 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)
+@Parameter(hidden = true)
 public @interface AuthorizedUser {
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/CommentErrorCode.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/CommentErrorCode.java
@@ -1,0 +1,31 @@
+package com.sparksInTheStep.webBoard.global.errorHandling.errorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum CommentErrorCode implements ErrorCode{
+    NOT_FOUND(HttpStatus.NOT_FOUND, "C000", "No such comment"),
+    NOT_MY_COMMENT(HttpStatus.FORBIDDEN, "C001", "You can delete only your comment");
+
+    private final HttpStatus httpStatus;
+    private final String errorCode;
+    private final String message;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public String code() {
+        return this.errorCode;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/PostErrorCode.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/PostErrorCode.java
@@ -1,0 +1,31 @@
+package com.sparksInTheStep.webBoard.global.errorHandling.errorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum PostErrorCode implements ErrorCode {
+    NOT_FOUND(HttpStatus.NOT_FOUND, "P000", "No such post");
+
+    private final HttpStatus httpStatus;
+    private final String errorCode;
+    private final String message;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public String code() {
+        return this.errorCode;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/global/filter/MemberArgumentResolver.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/filter/MemberArgumentResolver.java
@@ -1,7 +1,6 @@
 package com.sparksInTheStep.webBoard.global.filter;
 
-import com.sparksInTheStep.webBoard.auth.application.MemberService;
-import com.sparksInTheStep.webBoard.auth.application.dto.MemberInfo;
+import com.sparksInTheStep.webBoard.member.application.MemberService;
 import com.sparksInTheStep.webBoard.auth.token.JwtTokenProvider;
 import com.sparksInTheStep.webBoard.global.annotation.AuthorizedUser;
 import com.sparksInTheStep.webBoard.global.errorHandling.CustomException;

--- a/src/main/java/com/sparksInTheStep/webBoard/member/application/MemberService.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/application/MemberService.java
@@ -1,9 +1,9 @@
-package com.sparksInTheStep.webBoard.auth.application;
+package com.sparksInTheStep.webBoard.member.application;
 
-import com.sparksInTheStep.webBoard.auth.application.dto.MemberCommand;
-import com.sparksInTheStep.webBoard.auth.application.dto.MemberInfo;
-import com.sparksInTheStep.webBoard.auth.domain.Member;
-import com.sparksInTheStep.webBoard.auth.persistent.MemberRepository;
+import com.sparksInTheStep.webBoard.member.application.dto.MemberCommand;
+import com.sparksInTheStep.webBoard.member.application.dto.MemberInfo;
+import com.sparksInTheStep.webBoard.member.domain.Member;
+import com.sparksInTheStep.webBoard.member.persistent.MemberRepository;
 import com.sparksInTheStep.webBoard.global.errorHandling.CustomException;
 import com.sparksInTheStep.webBoard.global.errorHandling.errorCode.MemberErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -11,8 +11,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/sparksInTheStep/webBoard/member/application/dto/MemberCommand.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/application/dto/MemberCommand.java
@@ -1,6 +1,6 @@
-package com.sparksInTheStep.webBoard.auth.application.dto;
+package com.sparksInTheStep.webBoard.member.application.dto;
 
-import com.sparksInTheStep.webBoard.auth.presentation.dto.MemberRequest;
+import com.sparksInTheStep.webBoard.member.presentation.dto.MemberRequest;
 
 public record MemberCommand(String nickname, String password) {
     public static MemberCommand from(MemberRequest memberRequest){

--- a/src/main/java/com/sparksInTheStep/webBoard/member/application/dto/MemberInfo.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/application/dto/MemberInfo.java
@@ -1,6 +1,6 @@
-package com.sparksInTheStep.webBoard.auth.application.dto;
+package com.sparksInTheStep.webBoard.member.application.dto;
 
-import com.sparksInTheStep.webBoard.auth.domain.Member;
+import com.sparksInTheStep.webBoard.member.domain.Member;
 
 public record MemberInfo() {
     public record Default(String nickname){

--- a/src/main/java/com/sparksInTheStep/webBoard/member/domain/Member.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/domain/Member.java
@@ -1,4 +1,4 @@
-package com.sparksInTheStep.webBoard.auth.domain;
+package com.sparksInTheStep.webBoard.member.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/sparksInTheStep/webBoard/member/persistent/MemberRepository.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/persistent/MemberRepository.java
@@ -1,6 +1,6 @@
-package com.sparksInTheStep.webBoard.auth.persistent;
+package com.sparksInTheStep.webBoard.member.persistent;
 
-import com.sparksInTheStep.webBoard.auth.domain.Member;
+import com.sparksInTheStep.webBoard.member.domain.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/sparksInTheStep/webBoard/member/presentation/dto/MemberRequest.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/presentation/dto/MemberRequest.java
@@ -1,4 +1,4 @@
-package com.sparksInTheStep.webBoard.auth.presentation.dto;
+package com.sparksInTheStep.webBoard.member.presentation.dto;
 
 public record MemberRequest(String nickname, String password) {
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/member/presentation/dto/MemberResponse.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/presentation/dto/MemberResponse.java
@@ -1,6 +1,6 @@
-package com.sparksInTheStep.webBoard.auth.presentation.dto;
+package com.sparksInTheStep.webBoard.member.presentation.dto;
 
-import com.sparksInTheStep.webBoard.auth.application.dto.MemberInfo;
+import com.sparksInTheStep.webBoard.member.application.dto.MemberInfo;
 
 public record MemberResponse() {
     public record Default(String nickname){

--- a/src/main/java/com/sparksInTheStep/webBoard/post/controller/PostController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/post/controller/PostController.java
@@ -1,6 +1,6 @@
 package com.sparksInTheStep.webBoard.post.controller;
 
-import com.sparksInTheStep.webBoard.auth.application.dto.MemberInfo;
+import com.sparksInTheStep.webBoard.member.application.dto.MemberInfo;
 import com.sparksInTheStep.webBoard.post.controller.dto.PostRequest;
 import com.sparksInTheStep.webBoard.post.controller.dto.PostResponse;
 import com.sparksInTheStep.webBoard.post.service.PostService;

--- a/src/main/java/com/sparksInTheStep/webBoard/post/domain/Post.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/post/domain/Post.java
@@ -1,6 +1,6 @@
 package com.sparksInTheStep.webBoard.post.domain;
 
-import com.sparksInTheStep.webBoard.auth.domain.Member;
+import com.sparksInTheStep.webBoard.member.domain.Member;
 import com.sparksInTheStep.webBoard.post.service.dto.PostCommand;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/sparksInTheStep/webBoard/post/persistence/PostRepository.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/post/persistence/PostRepository.java
@@ -1,6 +1,6 @@
 package com.sparksInTheStep.webBoard.post.persistence;
 
-import com.sparksInTheStep.webBoard.auth.domain.Member;
+import com.sparksInTheStep.webBoard.member.domain.Member;
 import com.sparksInTheStep.webBoard.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/sparksInTheStep/webBoard/post/service/PostService.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/post/service/PostService.java
@@ -1,8 +1,8 @@
 package com.sparksInTheStep.webBoard.post.service;
 
-import com.sparksInTheStep.webBoard.auth.application.dto.MemberInfo;
-import com.sparksInTheStep.webBoard.auth.domain.Member;
-import com.sparksInTheStep.webBoard.auth.persistent.MemberRepository;
+import com.sparksInTheStep.webBoard.member.application.dto.MemberInfo;
+import com.sparksInTheStep.webBoard.member.domain.Member;
+import com.sparksInTheStep.webBoard.member.persistent.MemberRepository;
 import com.sparksInTheStep.webBoard.post.domain.Post;
 import com.sparksInTheStep.webBoard.post.persistence.PostRepository;
 import com.sparksInTheStep.webBoard.post.service.dto.PostCommand;

--- a/src/main/java/com/sparksInTheStep/webBoard/post/service/dto/PostInfo.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/post/service/dto/PostInfo.java
@@ -1,6 +1,6 @@
 package com.sparksInTheStep.webBoard.post.service.dto;
 
-import com.sparksInTheStep.webBoard.auth.application.dto.MemberInfo;
+import com.sparksInTheStep.webBoard.member.application.dto.MemberInfo;
 import com.sparksInTheStep.webBoard.post.domain.Post;
 import com.sparksInTheStep.webBoard.post.domain.PostType;
 

--- a/src/test/java/com/sparksInTheStep/webBoard/auth/application/MemberServiceTest.java
+++ b/src/test/java/com/sparksInTheStep/webBoard/auth/application/MemberServiceTest.java
@@ -1,8 +1,9 @@
 package com.sparksInTheStep.webBoard.auth.application;
 
-import com.sparksInTheStep.webBoard.auth.application.dto.MemberCommand;
-import com.sparksInTheStep.webBoard.auth.domain.Member;
-import com.sparksInTheStep.webBoard.auth.persistent.MemberRepository;
+import com.sparksInTheStep.webBoard.member.application.MemberService;
+import com.sparksInTheStep.webBoard.member.application.dto.MemberCommand;
+import com.sparksInTheStep.webBoard.member.domain.Member;
+import com.sparksInTheStep.webBoard.member.persistent.MemberRepository;
 import com.sun.jdi.request.DuplicateRequestException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/sparksInTheStep/webBoard/auth/domain/MemberTest.java
+++ b/src/test/java/com/sparksInTheStep/webBoard/auth/domain/MemberTest.java
@@ -1,5 +1,6 @@
 package com.sparksInTheStep.webBoard.auth.domain;
 
+import com.sparksInTheStep.webBoard.member.domain.Member;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/sparksInTheStep/webBoard/auth/persistent/MemberRepositoryTest.java
+++ b/src/test/java/com/sparksInTheStep/webBoard/auth/persistent/MemberRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.sparksInTheStep.webBoard.auth.persistent;
 
-import com.sparksInTheStep.webBoard.auth.domain.Member;
+import com.sparksInTheStep.webBoard.member.domain.Member;
+import com.sparksInTheStep.webBoard.member.persistent.MemberRepository;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.assertj.core.api.Assertions;


### PR DESCRIPTION
## PR 제목

### 구현 내용

- auth와 member 도메인 분리
- Swagger 사용을 위한 종속성 추가
- Comment, Post에 대한 커스텀 에러 코드 도입
- Swagger를 이용한 API 명세 작성
  - @AuthorizedUser의 정의에 @Parameter(hidden = true)을 추가하여, 명세에서 제외하도록 함
  - 명세를 작성한 도메인 : admin, auth, comment ( _post에 대한 명세는 보햄이 직접 작성해보시도록_ )

### 구현 이유

- member는 application 이전 까지만 로직을 짜고, 이를 사용하는 auth와 admin 도메인이 존재하는 구조로 변경
- Swagger 명세에 성공, 실패 시 HTTP Status code를 적기 위해 기존에 에러 코드를 적용하지 않았던 부분에도 적용

### 버그 리포트
