### PR TITLE
[feat] #27 Post 도메인에 페이징 적용

### DIFF
--- a/src/main/java/com/sparksInTheStep/webBoard/comment/presentation/CommentController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/comment/presentation/CommentController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/comment")
+@RequestMapping("/comments")
 public class CommentController implements CommentApiSpec{
     private final CommentService commentService;
 

--- a/src/main/java/com/sparksInTheStep/webBoard/post/application/PostService.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/post/application/PostService.java
@@ -10,6 +10,8 @@ import com.sparksInTheStep.webBoard.post.persistence.PostRepository;
 import com.sparksInTheStep.webBoard.post.application.dto.PostCommand;
 import com.sparksInTheStep.webBoard.post.application.dto.PostInfo;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,19 +31,16 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public List<PostInfo> getPostsByMember(MemberInfo.Default memberInfo) {
+    public Page<PostInfo> getPostsByMember(MemberInfo.Default memberInfo, Pageable pageable) {
         Member member = memberRepository.findByNickname(memberInfo.nickname());
+        Page<Post> posts = postRepository.findByMember(member, pageable);
 
-        List<Post> posts = postRepository.findByMember(member);
-
-        return posts.stream()
-                .map(PostInfo::from)
-                .toList();
+        return posts.map(PostInfo::from);
     }
 
     @Transactional(readOnly = true)
-    public List<PostInfo> getAllPosts(){
-        return postRepository.findAll().stream().map(PostInfo::from).toList();
+    public Page<PostInfo> getAllPosts(Pageable pageable){
+        return postRepository.findAll(pageable).map(PostInfo::from);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/sparksInTheStep/webBoard/post/persistence/PostRepository.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/post/persistence/PostRepository.java
@@ -2,13 +2,17 @@ package com.sparksInTheStep.webBoard.post.persistence;
 
 import com.sparksInTheStep.webBoard.member.domain.Member;
 import com.sparksInTheStep.webBoard.post.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-    List<Post> findByMember(Member member);
+    Page<Post> findAll(Pageable pageable);
+
+    Page<Post> findByMember(Member member, Pageable pageable);
 
     Optional<Post> findPostById(Long id);
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/post/presentation/PostApiSpec.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/post/presentation/PostApiSpec.java
@@ -8,6 +8,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,21 +18,24 @@ import java.util.List;
 
 @Tag(name="게시글 API", description = "게시글 기능을 담은 API")
 public interface PostApiSpec {
-    @Operation(summary = "모든 게시글 조회하기", description = "모든 게시글을 조회합니다")
-    @ApiResponse(responseCode="200", description = "성공")
-    public ResponseEntity<List<PostResponse>> getAllPosts();
-
     @Operation(summary = "특정 게시글 조회하기", description = "특정 게시글을 조회합니다")
     @ApiResponse(responseCode="200", description = "성공")
     @ApiResponse(responseCode = "404", description = "id에 해당하는 게시글이 없습니다")
-    public ResponseEntity<PostResponse> getPost(
+    public ResponseEntity<?> getPost(
             @PathVariable Long id
+    );
+
+    @Operation(summary = "모든 게시글 조회하기", description = "모든 게시글을 조회합니다")
+    @ApiResponse(responseCode="200", description = "성공")
+    public ResponseEntity<?> getAllPosts(
+            @PageableDefault Pageable pageable
     );
 
     @Operation(summary = "자기가 쓴 글 불러오기", description = "자기가 쓴 모든 글을 리스트로 반환합니다")
     @ApiResponse(responseCode="200", description = "성공")
     @ApiResponse(responseCode="404", description = "Bearer 토큰이 유효하지 않습니다")
-    public ResponseEntity<List<PostResponse>> getPostsByMember(
+    public ResponseEntity<?> getPostsByMember(
+            @PageableDefault Pageable pageable,
             @AuthorizedUser MemberInfo.Default memberInfo
     );
 
@@ -38,7 +43,7 @@ public interface PostApiSpec {
     @ApiResponse(responseCode="201", description = "성공")
     @ApiResponse(responseCode="404", description = "Bearer 토큰이 유효하지 않습니다")
     @ApiResponse(responseCode="500", description = "파라미터의 값이 유효하지 않습니다")
-    public ResponseEntity<Void> savePost(
+    public ResponseEntity<?> savePost(
             @AuthorizedUser MemberInfo.Default memberInfo,
             @Parameter(description = "제목과 바디 및 태그를 파라미터로 받습니다")
             @RequestBody PostRequest request
@@ -48,7 +53,7 @@ public interface PostApiSpec {
     @ApiResponse(responseCode="200", description = "성공")
     @ApiResponse(responseCode="404", description = "Bearer 토큰이 유효하지 않습니다")
     @ApiResponse(responseCode="500", description = "게시글 없거나 이미 게시글 번호 유효하지 않음")
-    public ResponseEntity<Void> updatePost(
+    public ResponseEntity<?> updatePost(
             @AuthorizedUser MemberInfo.Default memberInfo,
             @RequestBody PostRequest postRequest,
             @PathVariable Long postId
@@ -58,7 +63,7 @@ public interface PostApiSpec {
     @ApiResponse(responseCode="204", description = "성공")
     @ApiResponse(responseCode="404", description = "Bearer 토큰이 유효하지 않습니다")
     @ApiResponse(responseCode="500", description = "게시글 없거나 이미 게시글 번호 유효하지 않음")
-    public ResponseEntity<Void> deletePost(
+    public ResponseEntity<?> deletePost(
             @AuthorizedUser MemberInfo.Default memberInfo,
             @PathVariable Long postId
     );

--- a/src/main/java/com/sparksInTheStep/webBoard/post/presentation/PostController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/post/presentation/PostController.java
@@ -7,6 +7,9 @@ import com.sparksInTheStep.webBoard.post.application.PostService;
 import com.sparksInTheStep.webBoard.post.application.dto.PostCommand;
 import com.sparksInTheStep.webBoard.global.annotation.AuthorizedUser;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,35 +22,31 @@ import java.util.List;
 public class PostController implements PostApiSpec{
     private final PostService postService;
 
-    @GetMapping
-    public ResponseEntity<List<PostResponse>> getAllPosts(){
-        List<PostResponse> response = postService
-                .getAllPosts()
-                .stream()
-                .map(PostResponse::from)
-                .toList();
-        return ResponseEntity.ok(response);
-    }
     @GetMapping("/{id}")
-    public ResponseEntity<PostResponse> getPost(
+    public ResponseEntity<?> getPost(
             @PathVariable Long id
     ){
         PostResponse response = PostResponse.from(postService.getOnePost(id));
         return ResponseEntity.ok(response);
     }
+    @GetMapping
+    public ResponseEntity<?> getAllPosts(
+            @PageableDefault Pageable pageable
+    ){
+        Page<PostResponse> response = postService.getAllPosts(pageable).map(PostResponse::from);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
     @GetMapping("/my")
-    public ResponseEntity<List<PostResponse>> getPostsByMember(
+    public ResponseEntity<?> getPostsByMember(
+            @PageableDefault Pageable pageable,
             @AuthorizedUser MemberInfo.Default memberInfo
     ) {
-        List<PostResponse> response = postService
-                .getPostsByMember(memberInfo)
-                .stream()
-                .map(PostResponse::from)
-                .toList();
-        return ResponseEntity.ok(response);
+        Page<PostResponse> response = postService.getPostsByMember(memberInfo, pageable)
+                .map(PostResponse::from);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
     @PostMapping
-    public ResponseEntity<Void> savePost(
+    public ResponseEntity<?> savePost(
             @AuthorizedUser MemberInfo.Default memberInfo,
             @RequestBody PostRequest request
     ) {
@@ -55,7 +54,7 @@ public class PostController implements PostApiSpec{
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
     @PatchMapping("/{postId}")
-    public ResponseEntity<Void> updatePost(
+    public ResponseEntity<?> updatePost(
             @AuthorizedUser MemberInfo.Default memberInfo,
             @RequestBody PostRequest postRequest,
             @PathVariable Long postId
@@ -66,7 +65,7 @@ public class PostController implements PostApiSpec{
     }
 
     @DeleteMapping("/{postId}")
-    public ResponseEntity<Void> deletePost(
+    public ResponseEntity<?> deletePost(
             @AuthorizedUser MemberInfo.Default memberInfo,
             @PathVariable Long postId
     ) {


### PR DESCRIPTION
## PR 제목

### 구현 내용

- 다중 조회를 수행하는 GET /posts 와 GET /posts/my 에 대해 페이징 적용
- 단수 명사로 되어있던 comment 리소스를 복수형으로 변경

### 구현 이유

- 코딩 애플 선생님 가라사대, 내 서비스가 아무리 허접해도 1억 동접자를 상정하고 만드는게 개발자의 덕목이다.
- 페이징은 해야지

### 버그 리포트
