### PR TITLE
[Feat] #75 유저 취업 유무 정보 추가

### DIFF
--- a/src/main/java/com/sparksInTheStep/webBoard/member/application/MemberService.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/application/MemberService.java
@@ -22,7 +22,9 @@ public class MemberService {
     public boolean memberCheck(MemberCommand memberCommand){
         if(isExistMember(memberCommand.nickname())){
             Member savedMember = memberRepository.findByNickname(memberCommand.nickname());
-            Member checkMember = Member.of(memberCommand.nickname(), memberCommand.password());
+            Member checkMember = memberRepository.save(Member.of(
+                    memberCommand.nickname(), memberCommand.password(), memberCommand.employed()
+            ));
 
             return savedMember.passCheck(checkMember.getPassword());
         }
@@ -35,7 +37,19 @@ public class MemberService {
             throw CustomException.of(MemberErrorCode.DUPLICATED_NICKNAME);
         }
 
-        memberRepository.save(Member.of(memberCommand.nickname(), memberCommand.password()));
+        memberRepository.save(Member.of(
+                memberCommand.nickname(), memberCommand.password(), memberCommand.employed()
+        ));
+    }
+
+    @Transactional
+    public void updateEmployed(String nickname) {
+        if(!isExistMember(nickname)){
+            throw CustomException.of(MemberErrorCode.NOT_FOUND);
+        }
+
+        Member member = memberRepository.findByNickname(nickname);
+        member.employing();
     }
 
     // 관리자용
@@ -43,7 +57,9 @@ public class MemberService {
     public boolean adminCheck(MemberCommand memberCommand){
         if(!isNotAdminMember(memberCommand.nickname())){
             Member savedMember = memberRepository.findByNickname(memberCommand.nickname());
-            Member checkMember = Member.of(memberCommand.nickname(), memberCommand.password());
+            Member checkMember = memberRepository.save(Member.of(
+                    memberCommand.nickname(), memberCommand.password(), memberCommand.employed()
+            ));
 
             return savedMember.passCheck(checkMember.getPassword());
         }

--- a/src/main/java/com/sparksInTheStep/webBoard/member/application/dto/MemberCommand.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/application/dto/MemberCommand.java
@@ -2,8 +2,10 @@ package com.sparksInTheStep.webBoard.member.application.dto;
 
 import com.sparksInTheStep.webBoard.member.presentation.dto.MemberRequest;
 
-public record MemberCommand(String nickname, String password) {
+public record MemberCommand(String nickname, String password, Boolean employed) {
     public static MemberCommand from(MemberRequest memberRequest){
-        return new MemberCommand(memberRequest.nickname(), memberRequest.password());
+        return new MemberCommand(
+                memberRequest.nickname(), memberRequest.password(), memberRequest.employed()
+        );
     }
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/member/application/dto/MemberInfo.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/application/dto/MemberInfo.java
@@ -3,9 +3,9 @@ package com.sparksInTheStep.webBoard.member.application.dto;
 import com.sparksInTheStep.webBoard.member.domain.Member;
 
 public record MemberInfo() {
-    public record Default(String nickname){
+    public record Default(String nickname, Boolean employed){
         public static MemberInfo.Default from(Member member){
-            return new MemberInfo.Default(member.getNickname());
+            return new MemberInfo.Default(member.getNickname(), member.isEmployed());
         }
     }
 

--- a/src/main/java/com/sparksInTheStep/webBoard/member/domain/Member.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/domain/Member.java
@@ -21,19 +21,26 @@ public class Member {
     private UUID password;
     @Column(nullable = false)
     private boolean admin;
+    @Column(nullable = false)
+    private boolean employed;
 
-    private Member(String nickname, String password) {
+    private Member(String nickname, String password, Boolean employed) {
         this.nickname = nickname;
         this.password = encodePassword(password);
+        this.employed = employed;
         this.admin = false;
     }
 
-    public static Member of(String nickname, String password) {
-        return new Member(nickname, password);
+    public static Member of(String nickname, String password, Boolean employed) {
+        return new Member(nickname, password, employed);
     }
 
     public void granting() {
         this.admin = !this.admin;
+    }
+
+    public void employing() {
+        this.employed = !this.employed;
     }
 
     public boolean passCheck(UUID password) {

--- a/src/main/java/com/sparksInTheStep/webBoard/member/presentation/MemberApiSpec.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/presentation/MemberApiSpec.java
@@ -15,4 +15,10 @@ public interface MemberApiSpec {
     ResponseEntity<?> getNickname(
             @AuthorizedUser MemberInfo.Default memberInfo
     );
+
+    @Operation(summary = "유저 취업 여부 변경", description = "유저의 취업 유무를 변경합니다.")
+    @ApiResponse(responseCode="200", description = "성공")
+    ResponseEntity<?> updateEmployed(
+            @AuthorizedUser MemberInfo.Default memberInfo
+    );
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/member/presentation/MemberController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/presentation/MemberController.java
@@ -1,20 +1,33 @@
 package com.sparksInTheStep.webBoard.member.presentation;
 
 import com.sparksInTheStep.webBoard.global.annotation.AuthorizedUser;
+import com.sparksInTheStep.webBoard.member.application.MemberService;
 import com.sparksInTheStep.webBoard.member.application.dto.MemberInfo;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import java.util.List;
-
 @RequestMapping("/members")
+@RequiredArgsConstructor
 public class MemberController implements MemberApiSpec {
+    private final MemberService memberService;
+
     @GetMapping("/my/nickname")
     public ResponseEntity<?> getNickname(
             @AuthorizedUser MemberInfo.Default memberInfo
     ) {
         return new ResponseEntity<>(memberInfo.nickname(), HttpStatus.OK);
+    }
+
+    @PatchMapping("/my/employed")
+    public ResponseEntity<?> updateEmployed(
+            @AuthorizedUser MemberInfo.Default memberInfo
+    ) {
+        memberService.updateEmployed(memberInfo.nickname());
+
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/member/presentation/dto/MemberRequest.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/presentation/dto/MemberRequest.java
@@ -1,11 +1,9 @@
 package com.sparksInTheStep.webBoard.member.presentation.dto;
 
-import jakarta.validation.constraints.NotBlank;
-
 public record MemberRequest(
         String nickname,
-
-        String password
+        String password,
+        Boolean employed
 ) {
 
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/member/presentation/dto/MemberResponse.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/presentation/dto/MemberResponse.java
@@ -3,9 +3,9 @@ package com.sparksInTheStep.webBoard.member.presentation.dto;
 import com.sparksInTheStep.webBoard.member.application.dto.MemberInfo;
 
 public record MemberResponse() {
-    public record Default(String nickname){
+    public record Default(String nickname, Boolean employed){
         public static MemberResponse.Default from(MemberInfo.Default memberInfo){
-            return new MemberResponse.Default(memberInfo.nickname());
+            return new MemberResponse.Default(memberInfo.nickname(), memberInfo.employed());
         }
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,7 @@ spring.config.import=optional:file:.env[.properties]
 spring.h2.console.enabled=true
 
 # jpa-set
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.properties.hibernate.format_sql=true
 
 # add admin temporary

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -1,2 +1,2 @@
-INSERT INTO member (nickname, password, admin)
-VALUES ('admin', '00000000-02ca-001f-ffff-fffffd35ffe0', true);
+INSERT INTO member (nickname, password, admin, employed)
+VALUES ('admin', '00000000-02ca-001f-ffff-fffffd35ffe0', true, false);


### PR DESCRIPTION
## PR 제목

### 구현 내용

- 유저 엔티티의 필드에 취업 유무에 대한 부분 추가
- 해당 필드를 변경하는 API 구현 ( on, off 이진 변환 )

### 구현 이유

- 취업한 유저와 취업하지 않은 유저의 분류가 중요해져서

### 버그 리포트
