### PR TITLE
[Feat] #76 프로젝트 도메인과 기능 구현

### DIFF
--- a/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/ProjectErrorCode.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/ProjectErrorCode.java
@@ -1,0 +1,32 @@
+package com.sparksInTheStep.webBoard.global.errorHandling.errorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ProjectErrorCode implements ErrorCode{
+    NOT_FOUND(HttpStatus.NOT_FOUND, "Pr000", "No such project"),
+    NOT_TEAM_LEADER(HttpStatus.FORBIDDEN, "Pr001", "Project can be deleted by only team leader"),
+    ALREADY_EXIST_NAME(HttpStatus.FORBIDDEN, "Pr002", "Project's name is already using");
+
+    private final HttpStatus httpStatus;
+    private final String errorCode;
+    private final String message;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public String code() {
+        return this.errorCode;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/ProjectErrorCode.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/ProjectErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ProjectErrorCode implements ErrorCode{
     NOT_FOUND(HttpStatus.NOT_FOUND, "Pr000", "No such project"),
     NOT_TEAM_LEADER(HttpStatus.FORBIDDEN, "Pr001", "Project can be deleted by only team leader"),
-    ALREADY_EXIST_NAME(HttpStatus.FORBIDDEN, "Pr002", "Project's name is already using");
+    ALREADY_EXIST_NAME(HttpStatus.FORBIDDEN, "Pr002", "Project's name is already using"),
+    ALREADY_JOINED_PROJECT(HttpStatus.FORBIDDEN, "Pr003", "Login user already in this project");
 
     private final HttpStatus httpStatus;
     private final String errorCode;

--- a/src/main/java/com/sparksInTheStep/webBoard/member/domain/Member.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.sparksInTheStep.webBoard.member.domain;
 
+import com.sparksInTheStep.webBoard.project.doamin.Project;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -10,7 +11,6 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
-@Table(name = "member")
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,6 +21,9 @@ public class Member {
     private UUID password;
     @Column(nullable = false)
     private boolean admin;
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Project project;
 
     private Member(String nickname, String password) {
         this.nickname = nickname;

--- a/src/main/java/com/sparksInTheStep/webBoard/project/application/ProjectService.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/application/ProjectService.java
@@ -1,0 +1,65 @@
+package com.sparksInTheStep.webBoard.project.application;
+
+import com.sparksInTheStep.webBoard.global.errorHandling.CustomException;
+import com.sparksInTheStep.webBoard.global.errorHandling.errorCode.ProjectErrorCode;
+import com.sparksInTheStep.webBoard.project.application.dto.ProjectCommand;
+import com.sparksInTheStep.webBoard.project.application.dto.ProjectInfo;
+import com.sparksInTheStep.webBoard.project.doamin.Project;
+import com.sparksInTheStep.webBoard.project.persistent.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectService {
+    private final ProjectRepository projectRepository;
+
+    @Transactional(readOnly = true)
+    public Page<ProjectInfo> getAllProjects(Pageable pageable){
+        return projectRepository.findAll(pageable).map(ProjectInfo::of);
+    }
+    @Transactional(readOnly = true)
+    public ProjectInfo getProject(Long id){
+        Project project = projectRepository.findById(id).orElseThrow(
+                () -> CustomException.of(ProjectErrorCode.NOT_FOUND)
+        );
+        return ProjectInfo.of(project);
+    }
+    @Transactional
+    public void makeProject(ProjectCommand projectCommand){
+        if(projectRepository.existsByName(projectCommand.name())) {
+            throw CustomException.of(ProjectErrorCode.ALREADY_EXIST_NAME);
+        }
+        Project project = Project.of(projectCommand);
+        projectRepository.save(project);
+    }
+    @Transactional
+    public void updateProject(Long id, ProjectCommand projectCommand){
+        Project project = projectRepository.findById(id).orElseThrow(
+                () -> CustomException.of(ProjectErrorCode.NOT_FOUND)
+        );
+        if(projectRepository.existsByName(projectCommand.name())) {
+            throw CustomException.of(ProjectErrorCode.ALREADY_EXIST_NAME);
+        }
+        if(!project.getName().equals(projectCommand.nickname())) {
+            throw CustomException.of(ProjectErrorCode.NOT_TEAM_LEADER);
+        }
+
+        project.update(projectCommand.name(), projectCommand.info(), projectCommand.gitLink());
+    }
+
+    @Transactional
+    public void deleteProject(Long id, String nickname){
+        Project project = projectRepository.findById(id).orElseThrow(
+                () -> CustomException.of(ProjectErrorCode.NOT_FOUND)
+        );
+        if(!project.getName().equals(nickname)) {
+            throw CustomException.of(ProjectErrorCode.NOT_TEAM_LEADER);
+        }
+
+        projectRepository.delete(project);
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/project/application/dto/ProjectCommand.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/application/dto/ProjectCommand.java
@@ -1,0 +1,11 @@
+package com.sparksInTheStep.webBoard.project.application.dto;
+
+import com.sparksInTheStep.webBoard.project.presentation.dto.ProjectRequest;
+
+public record ProjectCommand(String name, String info, String gitLink, String nickname) {
+    public static ProjectCommand from(ProjectRequest projectRequest, String nickname) {
+        return new ProjectCommand(
+                projectRequest.name(), projectRequest.info(), projectRequest.gitLink(), nickname
+        );
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/project/application/dto/ProjectInfo.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/application/dto/ProjectInfo.java
@@ -1,0 +1,11 @@
+package com.sparksInTheStep.webBoard.project.application.dto;
+
+import com.sparksInTheStep.webBoard.project.doamin.Project;
+
+public record ProjectInfo(String name, String info, String gitLink, String leaderName) {
+    public static ProjectInfo of(Project project){
+        return new ProjectInfo(
+                project.getName(), project.getInfo(), project.getGitLink(), project.getLeaderName()
+        );
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/project/doamin/JoinedProject.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/doamin/JoinedProject.java
@@ -1,0 +1,33 @@
+package com.sparksInTheStep.webBoard.project.doamin;
+
+import com.sparksInTheStep.webBoard.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Getter
+public class JoinedProject {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+    @ManyToOne
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    private JoinedProject(Member member, Project project) {
+        this.member = member;
+        this.project = project;
+    }
+
+    public static JoinedProject from(
+            Member member, Project project
+    ){
+        return new JoinedProject(member, project);
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/project/doamin/Project.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/doamin/Project.java
@@ -1,0 +1,47 @@
+package com.sparksInTheStep.webBoard.project.doamin;
+
+import com.sparksInTheStep.webBoard.member.domain.Member;
+import com.sparksInTheStep.webBoard.project.application.dto.ProjectCommand;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Getter
+public class Project {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false, unique = true)
+    private String name;
+    @Column(nullable = false)
+    private String info;
+    @Column(nullable = false)
+    private String gitLink;
+    @Column(nullable = false)
+    private String leaderName;
+
+    private Project(String name, String info, String gitLink, String leaderName){
+        this.name = name;
+        this.info = info;
+        this.gitLink = gitLink;
+        this.leaderName = leaderName;
+    }
+
+    public static Project of(ProjectCommand projectCommand){
+        return new Project(
+                projectCommand.name(),
+                projectCommand.info(),
+                projectCommand.gitLink(),
+                projectCommand.name()
+        );
+    }
+
+    public void update(String name, String info, String gitLink){
+        this.name = name;
+        this.info = info;
+        this.gitLink = gitLink;
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/project/persistent/JoinedProjectRepository.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/persistent/JoinedProjectRepository.java
@@ -11,4 +11,6 @@ public interface JoinedProjectRepository extends JpaRepository<JoinedProject, Lo
     Page<JoinedProject> findJoinedProjectsByMember(Pageable pageable, Member member);
 
     Boolean existsByMemberAndProject(Member member, Project project);
+
+    void deleteByMemberAndProject(Member member, Project project);
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/project/persistent/JoinedProjectRepository.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/persistent/JoinedProjectRepository.java
@@ -1,0 +1,14 @@
+package com.sparksInTheStep.webBoard.project.persistent;
+
+import com.sparksInTheStep.webBoard.project.doamin.JoinedProject;
+import com.sparksInTheStep.webBoard.member.domain.Member;
+import com.sparksInTheStep.webBoard.project.doamin.Project;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JoinedProjectRepository extends JpaRepository<JoinedProject, Long> {
+    Page<JoinedProject> findJoinedProjectsByMember(Pageable pageable, Member member);
+
+    Boolean existsByMemberAndProject(Member member, Project project);
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/project/persistent/ProjectRepository.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/persistent/ProjectRepository.java
@@ -1,0 +1,12 @@
+package com.sparksInTheStep.webBoard.project.persistent;
+
+import com.sparksInTheStep.webBoard.project.doamin.Project;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+    Page<Project> findAll(Pageable pageable);
+
+    Boolean existsByName(String name);
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/project/presentation/ProjectApiSpec.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/presentation/ProjectApiSpec.java
@@ -1,0 +1,61 @@
+package com.sparksInTheStep.webBoard.project.presentation;
+
+import com.sparksInTheStep.webBoard.global.annotation.AuthorizedUser;
+import com.sparksInTheStep.webBoard.member.application.dto.MemberInfo;
+import com.sparksInTheStep.webBoard.project.presentation.dto.ProjectRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+public interface ProjectApiSpec {
+    @Operation(summary = "모든 프로젝트 조회", description = "모든 프로젝트를 조회합니다")
+    @ApiResponse(responseCode="200", description = "성공")
+    ResponseEntity<?> readAllProject(
+            @PageableDefault Pageable pageable
+    );
+    @Operation(summary = "특정 프로젝트 조회", description = "특정 프로젝트를 조회합니다")
+    @ApiResponse(responseCode="200", description = "성공")
+    ResponseEntity<?> readOneProject(
+            @PathVariable Long projectId
+    );
+    @Operation(summary = "프로젝트 생성", description = "프로젝트를 생성합니다")
+    @ApiResponse(responseCode="201", description = "성공")
+    ResponseEntity<?> createProject(
+            @RequestBody ProjectRequest projectRequest,
+            @AuthorizedUser MemberInfo.Default memberInfo
+    );
+    @Operation(summary = "프로젝트 수정", description = "프로젝트의 내용을 수정합니다 ( 프로젝트 장만 가능 )")
+    @ApiResponse(responseCode="200", description = "성공")
+    ResponseEntity<?> updateProject(
+            @PathVariable Long projectId,
+            @RequestBody ProjectRequest projectRequest,
+            @AuthorizedUser MemberInfo.Default memberInfo
+    );
+    @Operation(summary = "프로젝트 삭제", description = "프로젝트를 삭제합니다 ( 프로젝트 장만 가능 )")
+    @ApiResponse(responseCode="204", description = "성공")
+    ResponseEntity<?> deleteProject(
+            @PathVariable Long projectId,
+            @AuthorizedUser MemberInfo.Default memberInfo
+    );
+    @Operation(summary = "내가 가입된 프로젝트 조회", description = "가입한 프로젝트를 조회합니다")
+    @ApiResponse(responseCode="200", description = "성공")
+    ResponseEntity<?> readMyProject(
+            @PageableDefault Pageable pageable,
+            @AuthorizedUser MemberInfo.Default memberInfo
+    );
+    @Operation(summary = "프로젝트 가입", description = "프로젝트에 가입합니다")
+    @ApiResponse(responseCode="200", description = "성공")
+    ResponseEntity<?> joinToProject(
+            @PathVariable Long projectId,
+            @AuthorizedUser MemberInfo.Default memberInfo
+    );
+    @Operation(summary = "프로젝트 탈퇴", description = "프로젝트에서 탈퇴합니다")
+    @ApiResponse(responseCode="204", description = "성공")
+    ResponseEntity<?> withdrawProject(
+            @PathVariable Long projectId,
+            @AuthorizedUser MemberInfo.Default memberInfo
+    );
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/project/presentation/ProjectController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/presentation/ProjectController.java
@@ -66,4 +66,31 @@ public class ProjectController {
         projectService.deleteProject(projectId, memberInfo.nickname());
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
+
+    @GetMapping("/my")
+    public ResponseEntity<?> readMyProject(
+            @PageableDefault Pageable pageable,
+            @AuthorizedUser MemberInfo.Default memberInfo
+    ) {
+        Page<ProjectInfo> projects = projectService.getMyProjects(pageable, memberInfo.nickname());
+        return new ResponseEntity<>(projects.map(ProjectResponse::of), HttpStatus.OK);
+    }
+
+    @PostMapping("/{projectId}")
+    public ResponseEntity<?> joinToProject(
+            @PathVariable Long projectId,
+            @AuthorizedUser MemberInfo.Default memberInfo
+    ) {
+        projectService.joinProject(projectId, memberInfo.nickname());
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{projectId}")
+    public ResponseEntity<?> withdrawProject(
+            @PathVariable Long projectId,
+            @AuthorizedUser MemberInfo.Default memberInfo
+    ) {
+        projectService.withdrawProject(projectId, memberInfo.nickname());
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/project/presentation/ProjectController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/presentation/ProjectController.java
@@ -85,7 +85,7 @@ public class ProjectController implements ProjectApiSpec{
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @DeleteMapping("/{projectId}")
+    @DeleteMapping("/my/{projectId}")
     public ResponseEntity<?> withdrawProject(
             @PathVariable Long projectId,
             @AuthorizedUser MemberInfo.Default memberInfo

--- a/src/main/java/com/sparksInTheStep/webBoard/project/presentation/ProjectController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/presentation/ProjectController.java
@@ -1,0 +1,69 @@
+package com.sparksInTheStep.webBoard.project.presentation;
+
+import com.sparksInTheStep.webBoard.global.annotation.AuthorizedUser;
+import com.sparksInTheStep.webBoard.member.application.dto.MemberInfo;
+import com.sparksInTheStep.webBoard.project.application.ProjectService;
+import com.sparksInTheStep.webBoard.project.application.dto.ProjectCommand;
+import com.sparksInTheStep.webBoard.project.application.dto.ProjectInfo;
+import com.sparksInTheStep.webBoard.project.presentation.dto.ProjectRequest;
+import com.sparksInTheStep.webBoard.project.presentation.dto.ProjectResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/projects")
+public class ProjectController {
+    private final ProjectService projectService;
+
+    @GetMapping
+    public ResponseEntity<?> readAllProject(
+            @PageableDefault Pageable pageable
+    ){
+        Page<ProjectInfo> projects = projectService.getAllProjects(pageable);
+        return new ResponseEntity<>(projects.map(ProjectResponse::of), HttpStatus.OK);
+    }
+
+    @GetMapping("/{projectId}")
+    public ResponseEntity<?> readOneProject(
+            @PathVariable Long projectId
+    ){
+        ProjectInfo project = projectService.getProject(projectId);
+        return new ResponseEntity<>(ProjectResponse.of(project), HttpStatus.OK);
+    }
+
+    @PostMapping
+    public ResponseEntity<?> createProject(
+            @RequestBody ProjectRequest projectRequest,
+            @AuthorizedUser MemberInfo.Default memberInfo
+    ){
+        projectService.makeProject(ProjectCommand.from(projectRequest, memberInfo.nickname()));
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @PatchMapping("/{projectId}")
+    public ResponseEntity<?> updateProject(
+            @PathVariable Long projectId,
+            @RequestBody ProjectRequest projectRequest,
+            @AuthorizedUser MemberInfo.Default memberInfo
+    ) {
+        projectService.updateProject(
+                projectId, ProjectCommand.from(projectRequest, memberInfo.nickname())
+        );
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{projectId}")
+    public ResponseEntity<?> deleteProject(
+            @PathVariable Long projectId,
+            @AuthorizedUser MemberInfo.Default memberInfo
+    ) {
+        projectService.deleteProject(projectId, memberInfo.nickname());
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/project/presentation/ProjectController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/presentation/ProjectController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/projects")
-public class ProjectController {
+public class ProjectController implements ProjectApiSpec{
     private final ProjectService projectService;
 
     @GetMapping

--- a/src/main/java/com/sparksInTheStep/webBoard/project/presentation/dto/ProjectRequest.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/presentation/dto/ProjectRequest.java
@@ -1,0 +1,4 @@
+package com.sparksInTheStep.webBoard.project.presentation.dto;
+
+public record ProjectRequest(String name, String info, String gitLink) {
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/project/presentation/dto/ProjectResponse.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/presentation/dto/ProjectResponse.java
@@ -1,0 +1,14 @@
+package com.sparksInTheStep.webBoard.project.presentation.dto;
+
+import com.sparksInTheStep.webBoard.project.application.dto.ProjectInfo;
+
+public record ProjectResponse(String name, String info, String gitLink, String leaderName) {
+    public static ProjectResponse of(ProjectInfo projectInfo) {
+        return new ProjectResponse(
+                projectInfo.name(),
+                projectInfo.info(),
+                projectInfo.gitLink(),
+                projectInfo.leaderName()
+        );
+    }
+}


### PR DESCRIPTION
## PR 제목

### 구현 내용

- 프로젝트 도메인 및 기본적인 CRUD API와 기능 구현
- 프로젝트 도메인과 멤버 도메인의 연관관계를 표현하기 위한 도메인 구현
- 프로젝트 가입, 탈퇴, 내 프로젝트 조회 기능 구현

### 구현 이유

- 프로젝트에 대한 부분을 저장하기 위해서

### 버그 리포트
