### PR TITLE
[Refactor] #93 멤버 도메인 필드 수정 및 새로운 기능 구현

### DIFF
--- a/src/main/java/com/sparksInTheStep/webBoard/admin/presentation/AdminApiController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/admin/presentation/AdminApiController.java
@@ -28,7 +28,7 @@ public class AdminApiController {
             @PageableDefault Pageable pageable
     ) {
         return new ResponseEntity<>(
-                memberService.readAllMembers(memberInfo.nickname(),pageable)
+                memberService.readAllMembers(memberInfo.email(),pageable)
                         .map(MemberResponse.Special::from),
                 HttpStatus.OK
         );
@@ -40,8 +40,8 @@ public class AdminApiController {
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }
 
-        String accessToken = jwtTokenProvider.makeAccessToken(memberRequest.nickname());
-        String refreshToken = jwtTokenProvider.makeRefreshToken(memberRequest.nickname());
+        String accessToken = jwtTokenProvider.makeAccessToken(memberRequest.email());
+        String refreshToken = jwtTokenProvider.makeRefreshToken(memberRequest.email());
         return new ResponseEntity<>(Token.of(accessToken, refreshToken), HttpStatus.OK);
     }
 
@@ -50,7 +50,7 @@ public class AdminApiController {
             @AuthorizedUser MemberInfo.Default memberInfo,
             @PathVariable Long userId
     ) {
-        memberService.grantingMember(memberInfo.nickname(), userId);
+        memberService.grantingMember(memberInfo.email(), userId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
@@ -59,7 +59,7 @@ public class AdminApiController {
             @AuthorizedUser MemberInfo.Default memberInfo,
             @PathVariable Long userId
     ) {
-        memberService.deleteMember(memberInfo.nickname(), userId);
+        memberService.deleteMember(memberInfo.email(), userId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/presentation/AuthController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/presentation/AuthController.java
@@ -26,8 +26,8 @@ public class AuthController implements AuthApiSpec{
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }
 
-        String accessToken = jwtTokenProvider.makeAccessToken(memberRequest.nickname());
-        String refreshToken = jwtTokenProvider.makeRefreshToken(memberRequest.nickname());
+        String accessToken = jwtTokenProvider.makeAccessToken(memberRequest.email());
+        String refreshToken = jwtTokenProvider.makeRefreshToken(memberRequest.email());
         return new ResponseEntity<>(Token.of(accessToken, refreshToken), HttpStatus.OK);
     }
 
@@ -35,8 +35,8 @@ public class AuthController implements AuthApiSpec{
     public ResponseEntity<?> register(@RequestBody MemberRequest memberRequest){
         memberService.makeNewUser(MemberCommand.from(memberRequest));
 
-        String accessToken = jwtTokenProvider.makeAccessToken(memberRequest.nickname());
-        String refreshToken = jwtTokenProvider.makeRefreshToken(memberRequest.nickname());
+        String accessToken = jwtTokenProvider.makeAccessToken(memberRequest.email());
+        String refreshToken = jwtTokenProvider.makeRefreshToken(memberRequest.email());
         return new ResponseEntity<>(Token.of(accessToken, refreshToken), HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/auth/token/JwtTokenProvider.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/auth/token/JwtTokenProvider.java
@@ -19,12 +19,12 @@ public class JwtTokenProvider {
     /*
      * 액세스 토큰 생성 : Claim => nickname, "access"
      */
-    public String makeAccessToken(String nickname) {
+    public String makeAccessToken(String email) {
         long nowMillis = System.currentTimeMillis();
         Date now = new Date(System.currentTimeMillis());
 
         return Jwts.builder()
-                .claim("nickname", nickname)
+                .claim("email", email)
                 .claim("type", "access")
                 .issuedAt(now)
                 .expiration(new Date(nowMillis + validTime)) // 1시간
@@ -35,12 +35,12 @@ public class JwtTokenProvider {
     /*
      * 리프레시 토큰 생성 : Claim => nickname, "refresh"
      */
-    public String makeRefreshToken(String nickname) {
+    public String makeRefreshToken(String email) {
         long nowMillis = System.currentTimeMillis();
         Date now = new Date(System.currentTimeMillis());
 
         return Jwts.builder()
-                .claim("nickname", nickname)
+                .claim("email", email)
                 .claim("type", "refresh")
                 .issuedAt(now)
                 .expiration(new Date(nowMillis + validTime * 168)) // 7일
@@ -51,14 +51,14 @@ public class JwtTokenProvider {
     /*
      * 토큰에서 클레임 ( nickname ) 추출
      */
-    public String getNicknameFromToken(String token) {
+    public String getEmailFromToken(String token) {
         try {
             Claims claims = Jwts.parser()
                     .verifyWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
                     .build()
                     .parseSignedClaims(token)
                     .getPayload();
-            return claims.get("nickname", String.class);
+            return claims.get("email", String.class);
         } catch(Exception e){
             return "null";
         }

--- a/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/MemberErrorCode.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/MemberErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum MemberErrorCode implements ErrorCode{
     NOT_FOUND(HttpStatus.NOT_FOUND, "M000", "member finding fail"),
     DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "M001", "already exist nickname"),
-    NO_AUTHENTICATION(HttpStatus.FORBIDDEN, "M002", "you're not admin member");
+    DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "M002", "already exist email"),
+    NO_AUTHENTICATION(HttpStatus.FORBIDDEN, "M003", "you're not admin member");
 
     private final HttpStatus httpStatus;
     private final String errorCode;

--- a/src/main/java/com/sparksInTheStep/webBoard/member/application/MemberService.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/application/MemberService.java
@@ -47,9 +47,16 @@ public class MemberService {
 
     // 회원 정보 수정
     @Transactional
-    public void updateEmployed(String nickname) {
-        Member member = memberRepository.findByNickname(nickname);
-        member.employing();
+    public void updateMember(String email, MemberCommand memberCommand) {
+        Member member = memberRepository.findByEmail(email);
+
+        member.update(
+                memberCommand.nickname(),
+                memberCommand.password(),
+                memberCommand.employed(),
+                memberCommand.gitLink(),
+                memberCommand.resumeLink()
+        );
     }
 
     // 관리자 로그인

--- a/src/main/java/com/sparksInTheStep/webBoard/member/application/MemberService.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/application/MemberService.java
@@ -17,102 +17,78 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
     private final MemberRepository memberRepository;
 
-    // 일반 사용자용
+    // 로그인
     @Transactional(readOnly = true)
     public boolean memberCheck(MemberCommand memberCommand){
-        if(isExistMember(memberCommand.nickname())){
-            Member savedMember = memberRepository.findByNickname(memberCommand.nickname());
-            Member checkMember = Member.of(
-                    memberCommand.nickname(), memberCommand.password(), memberCommand.employed()
-            );
-
+        // 아이디 ( 이메일 ) 검증
+        if(memberRepository.existsByEmail(memberCommand.email())){
+            // 비밀번호 검증
+            Member savedMember = memberRepository.findByEmail(memberCommand.email());
+            Member checkMember = Member.of(memberCommand);
             return savedMember.passCheck(checkMember.getPassword());
         }
         return false;
     }
 
+    // 회원가입
     @Transactional
     public void makeNewUser(MemberCommand memberCommand){
-        if(isExistMember(memberCommand.nickname())){
+        // 이메일 중복 검사
+        if(memberRepository.existsByEmail(memberCommand.email())) {
+            throw CustomException.of(MemberErrorCode.DUPLICATED_EMAIL);
+        }
+        // 닉네임 중복 검사
+        if(memberRepository.existsByNickname(memberCommand.nickname())) {
             throw CustomException.of(MemberErrorCode.DUPLICATED_NICKNAME);
         }
 
-        memberRepository.save(Member.of(
-                memberCommand.nickname(), memberCommand.password(), memberCommand.employed()
-        ));
+        memberRepository.save(Member.of(memberCommand));
     }
 
+    // 회원 정보 수정
     @Transactional
     public void updateEmployed(String nickname) {
-        if(!isExistMember(nickname)){
-            throw CustomException.of(MemberErrorCode.NOT_FOUND);
-        }
-
         Member member = memberRepository.findByNickname(nickname);
         member.employing();
     }
 
-    // 관리자용
+    // 관리자 로그인
     @Transactional(readOnly = true)
     public boolean adminCheck(MemberCommand memberCommand){
-        if(!isNotAdminMember(memberCommand.nickname())){
-            Member savedMember = memberRepository.findByNickname(memberCommand.nickname());
-            Member checkMember = Member.of(
-                    memberCommand.nickname(), memberCommand.password(), memberCommand.employed()
+        return memberCheck(memberCommand) && isAdminMember(memberCommand.email());
+    }
+
+    @Transactional(readOnly = true)
+    public Page<MemberInfo.Special> readAllMembers(String email, Pageable pageable){
+        if(isAdminMember(email)){
+            return memberRepository.findAll(pageable).map(MemberInfo.Special::from);
+        }
+        throw CustomException.of(MemberErrorCode.NO_AUTHENTICATION);
+    }
+
+    @Transactional
+    public void grantingMember(String email, Long memberId) {
+        if(isAdminMember(email)){
+            Member savedMember = memberRepository.findById(memberId).orElseThrow(
+                    () -> CustomException.of(MemberErrorCode.NOT_FOUND)
             );
-
-            return savedMember.passCheck(checkMember.getPassword());
-        }
-        return false;
-    }
-
-    @Transactional(readOnly = true)
-    public Page<MemberInfo.Special> readAllMembers(String nickname, Pageable pageable){
-        if(isNotAdminMember(nickname)){
-            throw CustomException.of(MemberErrorCode.NO_AUTHENTICATION);
+            savedMember.granting();
         }
 
-        return memberRepository.findAll(pageable).map(MemberInfo.Special::from);
+        throw CustomException.of(MemberErrorCode.NO_AUTHENTICATION);
     }
 
     @Transactional
-    public void grantingMember(String adminNickname, Long memberId) {
-        if(isNotAdminMember(adminNickname)){
-            throw CustomException.of(MemberErrorCode.NO_AUTHENTICATION);
+    public void deleteMember(String email, Long memberId) {
+        if(isAdminMember(email)){
+            memberRepository.deleteById(memberId);
         }
 
-        Member savedMember = memberRepository.findById(memberId).orElseThrow(
-                () -> CustomException.of(MemberErrorCode.NOT_FOUND)
-        );
-        savedMember.granting();
-    }
-
-    @Transactional
-    public void deleteMember(String adminNickname, Long memberId) {
-        if(isNotAdminMember(adminNickname)){
-            throw CustomException.of(MemberErrorCode.NO_AUTHENTICATION);
-        }
-
-        memberRepository.deleteById(memberId);
-    }
-
-    // 필터 사용
-    @Transactional(readOnly = true)
-    public MemberInfo.Default loginMember(String nickname){
-        return MemberInfo.Default.from(memberRepository.findByNickname(nickname));
+        throw CustomException.of(MemberErrorCode.NO_AUTHENTICATION);
     }
 
     @Transactional(readOnly = true)
-    public boolean isExistMember(String nickname){
-        return memberRepository.existsByNickname(nickname);
-    }
-
-    @Transactional(readOnly = true)
-    public boolean isNotAdminMember(String nickname){
-        if(!isExistMember(nickname)){
-            throw CustomException.of(MemberErrorCode.NOT_FOUND);
-        }
-
-        return !memberRepository.findByNickname(nickname).adminCheck();
+    public boolean isAdminMember(String email){
+        return memberRepository.findByEmail(email).adminCheck();
     }
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/member/application/dto/MemberCommand.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/application/dto/MemberCommand.java
@@ -2,13 +2,21 @@ package com.sparksInTheStep.webBoard.member.application.dto;
 
 import com.sparksInTheStep.webBoard.member.presentation.dto.MemberRequest;
 
-public record MemberCommand(String email, String nickname, String password, Boolean employed) {
+public record MemberCommand(
+        String email,
+        String nickname,
+        String password,
+        Boolean employed,
+        String gitLink,
+        String resumeLink) {
     public static MemberCommand from(MemberRequest memberRequest){
         return new MemberCommand(
                 memberRequest.email(),
                 memberRequest.nickname(),
                 memberRequest.password(),
-                memberRequest.employed()
+                memberRequest.employed(),
+                memberRequest.gitLink(),
+                memberRequest.resumeLink()
         );
     }
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/member/application/dto/MemberCommand.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/application/dto/MemberCommand.java
@@ -2,10 +2,13 @@ package com.sparksInTheStep.webBoard.member.application.dto;
 
 import com.sparksInTheStep.webBoard.member.presentation.dto.MemberRequest;
 
-public record MemberCommand(String nickname, String password, Boolean employed) {
+public record MemberCommand(String email, String nickname, String password, Boolean employed) {
     public static MemberCommand from(MemberRequest memberRequest){
         return new MemberCommand(
-                memberRequest.nickname(), memberRequest.password(), memberRequest.employed()
+                memberRequest.email(),
+                memberRequest.nickname(),
+                memberRequest.password(),
+                memberRequest.employed()
         );
     }
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/member/application/dto/MemberInfo.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/application/dto/MemberInfo.java
@@ -3,15 +3,16 @@ package com.sparksInTheStep.webBoard.member.application.dto;
 import com.sparksInTheStep.webBoard.member.domain.Member;
 
 public record MemberInfo() {
-    public record Default(String nickname, Boolean employed){
+    public record Default(String email, String nickname, Boolean employed){
         public static MemberInfo.Default from(Member member){
-            return new MemberInfo.Default(member.getNickname(), member.isEmployed());
+            return new MemberInfo.Default(member.getEmail(),member.getNickname(), member.isEmployed());
         }
     }
 
-    public record Special(String nickname, Long id, boolean isAdmin){
+    public record Special(String email, String nickname, Long id, boolean isAdmin){
         public static MemberInfo.Special from(Member member){
-            return new MemberInfo.Special(member.getNickname(), member.getId(), member.isAdmin());
+            return new MemberInfo.Special(
+                    member.getEmail(), member.getNickname(), member.getId(), member.isAdmin());
         }
     }
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/member/application/dto/MemberInfo.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/application/dto/MemberInfo.java
@@ -3,9 +3,17 @@ package com.sparksInTheStep.webBoard.member.application.dto;
 import com.sparksInTheStep.webBoard.member.domain.Member;
 
 public record MemberInfo() {
-    public record Default(String email, String nickname, Boolean employed){
+    public record Default(
+            String email, String nickname, Boolean employed, String gitLink, String resumeLink
+    ){
         public static MemberInfo.Default from(Member member){
-            return new MemberInfo.Default(member.getEmail(),member.getNickname(), member.isEmployed());
+            return new MemberInfo.Default(
+                    member.getEmail(),
+                    member.getNickname(),
+                    member.isEmployed(),
+                    member.getGitLink(),
+                    member.getResumeLink()
+            );
         }
     }
 

--- a/src/main/java/com/sparksInTheStep/webBoard/member/domain/Member.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.sparksInTheStep.webBoard.member.domain;
 
+import com.sparksInTheStep.webBoard.member.application.dto.MemberCommand;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -17,7 +18,7 @@ public class Member {
     private Long id;
     @Column(unique = true, nullable = false)
     private String email;
-    @Column(unique = true, nullable = false)
+    @Column(unique = true)
     private String nickname;
     @Column(nullable = false)
     private UUID password;
@@ -25,17 +26,37 @@ public class Member {
     private boolean admin;
     @Column(nullable = false)
     private boolean employed;
+    @Column
+    private String gitLink;
+    @Column
+    private String resumeLink;
 
-    private Member(String email, String nickname, String password, Boolean employed) {
+    private Member(
+            String email,
+            String nickname,
+            String password,
+            Boolean employed,
+            String gitLink,
+            String resumeLink
+    ) {
         this.email = email;
         this.nickname = nickname;
         this.password = encodePassword(password);
         this.employed = employed;
         this.admin = false;
+        this.gitLink = gitLink;
+        this.resumeLink = resumeLink;
     }
 
-    public static Member of(String email, String nickname, String password, Boolean employed) {
-        return new Member(email, nickname, password, employed);
+    public static Member of(MemberCommand memberCommand) {
+        return new Member(
+                memberCommand.email(),
+                memberCommand.nickname(),
+                memberCommand.password(),
+                memberCommand.employed(),
+                memberCommand.gitLink(),
+                memberCommand.resumeLink()
+        );
     }
 
     public void granting() {

--- a/src/main/java/com/sparksInTheStep/webBoard/member/domain/Member.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/domain/Member.java
@@ -63,8 +63,14 @@ public class Member {
         this.admin = !this.admin;
     }
 
-    public void employing() {
-        this.employed = !this.employed;
+    public void update(
+            String nickname, String password, Boolean employed, String gitLink, String resumeLink
+    ) {
+        this.nickname = nickname;
+        this.password = encodePassword(password);
+        this.employed = employed;
+        this.gitLink = gitLink;
+        this.resumeLink = resumeLink;
     }
 
     public boolean passCheck(UUID password) {

--- a/src/main/java/com/sparksInTheStep/webBoard/member/domain/Member.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/domain/Member.java
@@ -1,6 +1,5 @@
 package com.sparksInTheStep.webBoard.member.domain;
 
-import com.sparksInTheStep.webBoard.project.doamin.Project;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -17,6 +16,8 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Column(unique = true, nullable = false)
+    private String email;
+    @Column(unique = true, nullable = false)
     private String nickname;
     @Column(nullable = false)
     private UUID password;
@@ -25,15 +26,16 @@ public class Member {
     @Column(nullable = false)
     private boolean employed;
 
-    private Member(String nickname, String password, Boolean employed) {
+    private Member(String email, String nickname, String password, Boolean employed) {
+        this.email = email;
         this.nickname = nickname;
         this.password = encodePassword(password);
         this.employed = employed;
         this.admin = false;
     }
 
-    public static Member of(String nickname, String password, Boolean employed) {
-        return new Member(nickname, password, employed);
+    public static Member of(String email, String nickname, String password, Boolean employed) {
+        return new Member(email, nickname, password, employed);
     }
 
     public void granting() {

--- a/src/main/java/com/sparksInTheStep/webBoard/member/persistent/MemberRepository.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/persistent/MemberRepository.java
@@ -10,5 +10,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByNickname(String nickname);
 
+    boolean existsByEmail(String email);
+
     Member findByNickname(String nickname);
+
+    Member findByEmail(String email);
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/member/presentation/MemberApiSpec.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/presentation/MemberApiSpec.java
@@ -2,23 +2,20 @@ package com.sparksInTheStep.webBoard.member.presentation;
 
 import com.sparksInTheStep.webBoard.global.annotation.AuthorizedUser;
 import com.sparksInTheStep.webBoard.member.application.dto.MemberInfo;
+import com.sparksInTheStep.webBoard.member.presentation.dto.MemberRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 
 
 @Tag(name="유저 API", description = "유저 마이 페이지 API")
 public interface MemberApiSpec {
-    @Operation(summary = "유저 닉네임 정보 조회하기", description = "유저의 닉네임을 반환합니다.")
+    @Operation(summary = "유저 정보 변경", description = "유저의 정보를 변경합니다.")
     @ApiResponse(responseCode="200", description = "성공")
-    ResponseEntity<?> getNickname(
-            @AuthorizedUser MemberInfo.Default memberInfo
-    );
-
-    @Operation(summary = "유저 취업 여부 변경", description = "유저의 취업 유무를 변경합니다.")
-    @ApiResponse(responseCode="200", description = "성공")
-    ResponseEntity<?> updateEmployed(
-            @AuthorizedUser MemberInfo.Default memberInfo
+    ResponseEntity<?> updateMember(
+            @AuthorizedUser MemberInfo.Default memberInfo,
+            @RequestBody MemberRequest memberRequest
     );
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/member/presentation/MemberController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/presentation/MemberController.java
@@ -2,12 +2,14 @@ package com.sparksInTheStep.webBoard.member.presentation;
 
 import com.sparksInTheStep.webBoard.global.annotation.AuthorizedUser;
 import com.sparksInTheStep.webBoard.member.application.MemberService;
+import com.sparksInTheStep.webBoard.member.application.dto.MemberCommand;
 import com.sparksInTheStep.webBoard.member.application.dto.MemberInfo;
+import com.sparksInTheStep.webBoard.member.presentation.dto.MemberRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @RequestMapping("/members")
@@ -15,18 +17,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class MemberController implements MemberApiSpec {
     private final MemberService memberService;
 
-    @GetMapping("/my/nickname")
-    public ResponseEntity<?> getNickname(
-            @AuthorizedUser MemberInfo.Default memberInfo
+    @PutMapping("/my")
+    public ResponseEntity<?> updateMember(
+            @AuthorizedUser MemberInfo.Default memberInfo,
+            @RequestBody MemberRequest memberRequest
     ) {
-        return new ResponseEntity<>(memberInfo.nickname(), HttpStatus.OK);
-    }
-
-    @PatchMapping("/my/employed")
-    public ResponseEntity<?> updateEmployed(
-            @AuthorizedUser MemberInfo.Default memberInfo
-    ) {
-        memberService.updateEmployed(memberInfo.nickname());
+        memberService.updateMember(memberInfo.email(), MemberCommand.from(memberRequest));
 
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/src/main/java/com/sparksInTheStep/webBoard/member/presentation/dto/MemberRequest.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/presentation/dto/MemberRequest.java
@@ -4,7 +4,9 @@ public record MemberRequest(
         String email,
         String nickname,
         String password,
-        Boolean employed
+        Boolean employed,
+        String gitLink,
+        String resumeLink
 ) {
 
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/member/presentation/dto/MemberRequest.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/presentation/dto/MemberRequest.java
@@ -1,6 +1,7 @@
 package com.sparksInTheStep.webBoard.member.presentation.dto;
 
 public record MemberRequest(
+        String email,
         String nickname,
         String password,
         Boolean employed

--- a/src/main/java/com/sparksInTheStep/webBoard/member/presentation/dto/MemberResponse.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/presentation/dto/MemberResponse.java
@@ -3,10 +3,19 @@ package com.sparksInTheStep.webBoard.member.presentation.dto;
 import com.sparksInTheStep.webBoard.member.application.dto.MemberInfo;
 
 public record MemberResponse() {
-    public record Default(String email, String nickname, Boolean employed){
+    public record Default(
+            String email,
+            String nickname,
+            Boolean employed,
+            String gitLink,
+            String resumeLink){
         public static MemberResponse.Default from(MemberInfo.Default memberInfo){
             return new MemberResponse.Default(
-                    memberInfo.email(), memberInfo.nickname(), memberInfo.employed()
+                    memberInfo.email(),
+                    memberInfo.nickname(),
+                    memberInfo.employed(),
+                    memberInfo.gitLink(),
+                    memberInfo.resumeLink()
             );
         }
     }

--- a/src/main/java/com/sparksInTheStep/webBoard/member/presentation/dto/MemberResponse.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/presentation/dto/MemberResponse.java
@@ -3,15 +3,19 @@ package com.sparksInTheStep.webBoard.member.presentation.dto;
 import com.sparksInTheStep.webBoard.member.application.dto.MemberInfo;
 
 public record MemberResponse() {
-    public record Default(String nickname, Boolean employed){
+    public record Default(String email, String nickname, Boolean employed){
         public static MemberResponse.Default from(MemberInfo.Default memberInfo){
-            return new MemberResponse.Default(memberInfo.nickname(), memberInfo.employed());
+            return new MemberResponse.Default(
+                    memberInfo.email(), memberInfo.nickname(), memberInfo.employed()
+            );
         }
     }
 
-    public record Special(String nickname, Long id, boolean isAdmin){
+    public record Special(String email, String nickname, Long id, boolean isAdmin){
         public static MemberResponse.Special from(MemberInfo.Special memberInfo){
-            return new MemberResponse.Special(memberInfo.nickname(), memberInfo.id(), memberInfo.isAdmin());
+            return new MemberResponse.Special(
+                    memberInfo.email(), memberInfo.nickname(), memberInfo.id(), memberInfo.isAdmin()
+            );
         }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,7 @@ spring.config.import=optional:file:.env[.properties]
 
 # h2-console enable
 spring.h2.console.enabled=true
+spring.datasource.url = jdbc:h2:mem:test
 
 # jpa-set
 spring.jpa.hibernate.ddl-auto=create-drop

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -1,2 +1,2 @@
-INSERT INTO member (nickname, password, admin, employed)
-VALUES ('admin', '00000000-02ca-001f-ffff-fffffd35ffe0', true, false);
+INSERT INTO member (email, nickname, password, admin, employed, git_link, resume_link)
+VALUES ('admin@gmail.com', 'admin', '00000000-02ca-001f-ffff-fffffd35ffe0', true, false, 'a', 'a');

--- a/src/main/resources/static/js/admin.js
+++ b/src/main/resources/static/js/admin.js
@@ -56,6 +56,7 @@ function getMembers(page){
         },
         error: function(err) {
             alert("권한이 없습니다!");
+            localStorage.clear();
             window.location.href = '/admin/login';
         }
     });

--- a/src/main/resources/static/js/login.js
+++ b/src/main/resources/static/js/login.js
@@ -9,7 +9,7 @@ $(document).ready(function() {
     // 로그인 버튼 클릭 시 동작
     $("#login").click(function(){
         var user = {
-            nickname : $("#userId").val(),
+            email: $("#userId").val(),
             password : $("#password").val(),
             employed : false
         };

--- a/src/main/resources/templates/loginPage.html
+++ b/src/main/resources/templates/loginPage.html
@@ -13,7 +13,7 @@
     <h1>로그인</h1>
 
     <div class="form-inline">
-        <label for="userId">닉네임:</label>
+        <label for="userId">이메일:</label>
         <input type="text" id="userId" name="userId" required>
     </div>
     <div class="form-inline">


### PR DESCRIPTION
## PR 제목

### 구현 내용

- 닉네임과 이메일 필드 분리
- 깃허브와 이력서 링크를 달 수 있는 필드 생성
- 이메일이 아이디의 역할을 하게 됨에 따라 로직 리펙터링
- 개인 정보를 수정할 수 있는 API 및 기능 구현 ( Email은 바꿀 수 없음 )

### 구현 이유

- 더 나은 사용자 경험을 위해
- 링크를 통해 조언을 구하기 위하여
- 로그인시 닉네임이 null 값으로 전달되기 때문에 해당 로직을 전부 이메일로 변경

### 버그 리포트
