### PR TITLE
[Feat] #111 - 요청 및 수락 방식으로 변경

### DIFF
--- a/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/ProjectErrorCode.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/global/errorHandling/errorCode/ProjectErrorCode.java
@@ -12,7 +12,8 @@ public enum ProjectErrorCode implements ErrorCode{
     ALREADY_EXIST_NAME(HttpStatus.FORBIDDEN, "Pr002", "Project's name is already using"),
     ALREADY_JOINED_PROJECT(HttpStatus.FORBIDDEN, "Pr003", "Login user already in this project"),
     OVER_TEAM_SIZE(HttpStatus.FORBIDDEN, "Pr004", "Team is full, check team size"),
-    LOGICAL_TEAM_SIZE_ERROR(HttpStatus.FORBIDDEN, "Pr005", "Team member size only can positive integer value");
+    LOGICAL_TEAM_SIZE_ERROR(HttpStatus.FORBIDDEN, "Pr005", "Team member size only can positive integer value"),
+    NO_SUCH_REQUEST(HttpStatus.NOT_FOUND, "Pr006", "No request Found");
 
     private final HttpStatus httpStatus;
     private final String errorCode;

--- a/src/main/java/com/sparksInTheStep/webBoard/member/presentation/MemberApiSpec.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/presentation/MemberApiSpec.java
@@ -16,6 +16,6 @@ public interface MemberApiSpec {
     @ApiResponse(responseCode="200", description = "성공")
     ResponseEntity<?> updateMember(
             @AuthorizedUser MemberInfo.Default memberInfo,
-            @RequestBody MemberRequest memberRequest
+            @RequestBody MemberRequest.Register memberRequest
     );
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/member/presentation/MemberController.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/member/presentation/MemberController.java
@@ -20,7 +20,7 @@ public class MemberController implements MemberApiSpec {
     @PutMapping("/my")
     public ResponseEntity<?> updateMember(
             @AuthorizedUser MemberInfo.Default memberInfo,
-            @RequestBody MemberRequest memberRequest
+            @RequestBody MemberRequest.Register memberRequest
     ) {
         memberService.updateMember(memberInfo.email(), MemberCommand.from(memberRequest));
 

--- a/src/main/java/com/sparksInTheStep/webBoard/project/application/ProjectService.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/application/ProjectService.java
@@ -2,13 +2,16 @@ package com.sparksInTheStep.webBoard.project.application;
 
 import com.sparksInTheStep.webBoard.global.errorHandling.CustomException;
 import com.sparksInTheStep.webBoard.global.errorHandling.errorCode.ProjectErrorCode;
+import com.sparksInTheStep.webBoard.project.application.dto.ProjectMemberRequestInfo;
 import com.sparksInTheStep.webBoard.project.doamin.JoinedProject;
+import com.sparksInTheStep.webBoard.project.doamin.ProjectMemberRequest;
 import com.sparksInTheStep.webBoard.project.persistent.JoinedProjectRepository;
 import com.sparksInTheStep.webBoard.member.domain.Member;
 import com.sparksInTheStep.webBoard.member.persistent.MemberRepository;
 import com.sparksInTheStep.webBoard.project.application.dto.ProjectCommand;
 import com.sparksInTheStep.webBoard.project.application.dto.ProjectInfo;
 import com.sparksInTheStep.webBoard.project.doamin.Project;
+import com.sparksInTheStep.webBoard.project.persistent.ProjectMemberRequestRepository;
 import com.sparksInTheStep.webBoard.project.persistent.ProjectRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -16,12 +19,16 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class ProjectService {
     private final ProjectRepository projectRepository;
     private final MemberRepository memberRepository;
     private final JoinedProjectRepository joinedProjectRepository;
+    private final ProjectMemberRequestRepository projectMemberRequestRepository;
 
     @Transactional(readOnly = true)
     public Page<ProjectInfo> getAllProjects(Pageable pageable){
@@ -55,25 +62,6 @@ public class ProjectService {
 
         Project project = Project.of(projectCommand);
         projectRepository.save(project);
-    }
-
-    @Transactional
-    public void joinProject(Long id, String nickname) {
-        Project project = projectRepository.findById(id).orElseThrow(
-                () -> CustomException.of(ProjectErrorCode.NOT_FOUND)
-        );
-        Member member = memberRepository.findByNickname(nickname);
-
-        if(project.getNowCount() == project.getMaxCount()) {
-            throw CustomException.of(ProjectErrorCode.OVER_TEAM_SIZE);
-        }
-        if(joinedProjectRepository.existsByMemberAndProject(member, project)){
-            throw CustomException.of(ProjectErrorCode.ALREADY_JOINED_PROJECT);
-        }
-
-        project.join();
-        JoinedProject joinedProject = JoinedProject.from(member, project);
-        joinedProjectRepository.save(joinedProject);
     }
 
     @Transactional
@@ -127,5 +115,51 @@ public class ProjectService {
             projectRepository.delete(project);
         }
         joinedProjectRepository.deleteByMemberAndProject(member, project);
+    }
+
+    @Transactional
+    public void joinProject(Long id, String nickname) {
+        Project project = projectRepository.findById(id).orElseThrow(
+                () -> CustomException.of(ProjectErrorCode.NOT_FOUND)
+        );
+        Member member = memberRepository.findByNickname(nickname);
+
+        if(project.getNowCount() == project.getMaxCount()) {
+            throw CustomException.of(ProjectErrorCode.OVER_TEAM_SIZE);
+        }
+        if(joinedProjectRepository.existsByMemberAndProject(member, project)){
+            throw CustomException.of(ProjectErrorCode.ALREADY_JOINED_PROJECT);
+        }
+
+        ProjectMemberRequest projectMemberRequest = ProjectMemberRequest.from(project, member);
+        projectMemberRequestRepository.save(projectMemberRequest);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProjectMemberRequestInfo> readProjectJoinRequest(String nickname) {
+        List<ProjectMemberRequest> requests =
+                projectMemberRequestRepository.findProjectMemberRequestByMember_Nickname(nickname);
+        return requests.stream().map(ProjectMemberRequestInfo::of).toList();
+    }
+
+    @Transactional
+    public void choice(String nickname, Long requestId, boolean tf) {
+        ProjectMemberRequest request = projectMemberRequestRepository.findById(requestId).
+                orElseThrow(() -> CustomException.of(ProjectErrorCode.NO_SUCH_REQUEST));
+
+        if(!request.getProject().getLeaderName().equals(nickname)) {
+            throw CustomException.of(ProjectErrorCode.NOT_TEAM_LEADER);
+        }
+
+        if(tf) {
+            Member member = request.getMember();
+            Project project = request.getProject();
+
+            project.join();
+            JoinedProject joinedProject = JoinedProject.from(member, project);
+            joinedProjectRepository.save(joinedProject);
+        }
+
+        projectMemberRequestRepository.delete(request);
     }
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/project/application/dto/ProjectMemberRequestInfo.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/application/dto/ProjectMemberRequestInfo.java
@@ -1,0 +1,23 @@
+package com.sparksInTheStep.webBoard.project.application.dto;
+
+import com.sparksInTheStep.webBoard.project.doamin.ProjectMemberRequest;
+
+import java.util.Date;
+
+public record ProjectMemberRequestInfo(
+        String projectName,
+        String requestMemberName,
+        int maxCount,
+        int nowCount,
+        Date deadline
+) {
+    public static ProjectMemberRequestInfo of(ProjectMemberRequest projectMemberRequest) {
+        return new ProjectMemberRequestInfo(
+                projectMemberRequest.getProject().getName(),
+                projectMemberRequest.getMember().getNickname(),
+                projectMemberRequest.getProject().getMaxCount(),
+                projectMemberRequest.getProject().getNowCount(),
+                projectMemberRequest.getProject().getDeadline()
+        );
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/project/doamin/ProjectMemberRequest.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/doamin/ProjectMemberRequest.java
@@ -1,0 +1,37 @@
+package com.sparksInTheStep.webBoard.project.doamin;
+
+import com.sparksInTheStep.webBoard.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Getter
+public class ProjectMemberRequest {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private boolean state;
+
+    private ProjectMemberRequest(Project project, Member member){
+        this.project = project;
+        this.member = member;
+        this.state = false;
+    }
+
+    public static ProjectMemberRequest from(Project project, Member member) {
+        return new ProjectMemberRequest(project, member);
+    }
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/project/persistent/ProjectMemberRequestRepository.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/persistent/ProjectMemberRequestRepository.java
@@ -1,0 +1,10 @@
+package com.sparksInTheStep.webBoard.project.persistent;
+
+import com.sparksInTheStep.webBoard.project.doamin.ProjectMemberRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProjectMemberRequestRepository extends JpaRepository<ProjectMemberRequest, Long> {
+    List<ProjectMemberRequest> findProjectMemberRequestByMember_Nickname(String nickname);
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/project/presentation/ProjectApiSpec.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/presentation/ProjectApiSpec.java
@@ -2,6 +2,7 @@ package com.sparksInTheStep.webBoard.project.presentation;
 
 import com.sparksInTheStep.webBoard.global.annotation.AuthorizedUser;
 import com.sparksInTheStep.webBoard.member.application.dto.MemberInfo;
+import com.sparksInTheStep.webBoard.project.presentation.dto.Choice;
 import com.sparksInTheStep.webBoard.project.presentation.dto.ProjectRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -48,7 +49,7 @@ public interface ProjectApiSpec {
             @PageableDefault Pageable pageable,
             @AuthorizedUser MemberInfo.Default memberInfo
     );
-    @Operation(summary = "프로젝트 가입", description = "프로젝트에 가입합니다")
+    @Operation(summary = "프로젝트 가입요청", description = "프로젝트에 가입을 요청합니다")
     @ApiResponse(responseCode="200", description = "성공")
     ResponseEntity<?> joinToProject(
             @PathVariable Long projectId,
@@ -59,5 +60,17 @@ public interface ProjectApiSpec {
     ResponseEntity<?> withdrawProject(
             @PathVariable Long projectId,
             @AuthorizedUser MemberInfo.Default memberInfo
+    );
+    @Operation(summary = "프로젝트 가입 요청 조회", description = "내가 리더인 프로젝트에 대한 요청을 조회합니다")
+    @ApiResponse(responseCode="200", description = "성공")
+    ResponseEntity<?> readMyProjectRequest(
+            @AuthorizedUser MemberInfo.Default memberInfo
+    );
+    @Operation(summary = "프로젝트 가입 결정", description = "내가 리더인 프로젝트에 대한 요청을 승인 혹은 거절합니다")
+    @ApiResponse(responseCode="200", description = "성공")
+    ResponseEntity<?> choiceRequest(
+            @AuthorizedUser MemberInfo.Default memberInfo,
+            @RequestBody Choice tf,
+            @PathVariable Long requestId
     );
 }

--- a/src/main/java/com/sparksInTheStep/webBoard/project/presentation/dto/Choice.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/presentation/dto/Choice.java
@@ -1,0 +1,4 @@
+package com.sparksInTheStep.webBoard.project.presentation.dto;
+
+public record Choice(boolean tf) {
+}

--- a/src/main/java/com/sparksInTheStep/webBoard/project/presentation/dto/ProjectMemberRequestResponse.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/project/presentation/dto/ProjectMemberRequestResponse.java
@@ -1,0 +1,23 @@
+package com.sparksInTheStep.webBoard.project.presentation.dto;
+
+import com.sparksInTheStep.webBoard.project.application.dto.ProjectMemberRequestInfo;
+
+import java.util.Date;
+
+public record ProjectMemberRequestResponse(
+        String projectName,
+        String requestMemberName,
+        int maxCount,
+        int nowCount,
+        Date deadline
+) {
+    public static ProjectMemberRequestResponse of(ProjectMemberRequestInfo requestInfo) {
+        return new ProjectMemberRequestResponse(
+            requestInfo.projectName(),
+            requestInfo.requestMemberName(),
+            requestInfo.maxCount(),
+            requestInfo.nowCount(),
+            requestInfo.deadline()
+        );
+    };
+}


### PR DESCRIPTION
## PR 제목

### 구현 내용

- 프로젝트 요청 도메인 생성
- 이를 위한 DTO 생성
- 요청, 요청 조회, 요청 수락 or 거절 로직 구현
- API 구현

### 구현 이유

- 수락없이 가입이 되면 유저 경험적으로 좋지 않음

### 버그 리포트
