### PR TITLE
refactor : Swagger의 Generated Server Url을 https 사용하는 실제 배포서버로 동적 할당

### DIFF
--- a/src/main/java/com/sparksInTheStep/webBoard/WebBoardApplication.java
+++ b/src/main/java/com/sparksInTheStep/webBoard/WebBoardApplication.java
@@ -1,11 +1,18 @@
 package com.sparksInTheStep.webBoard;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@OpenAPIDefinition(
+		servers = {
+				@Server(url = "/", description = "Default Server url")
+		}
+)
 public class WebBoardApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
## PR 제목

### 구현 내용

---

### 구현 이유

---

### 버그 리포트
